### PR TITLE
Add firefox installer pings to the allowlist

### DIFF
--- a/allowlist
+++ b/allowlist
@@ -4,3 +4,4 @@ org-mozilla-reference-browser/.*
 activity-stream/.*
 eng-workflow/bmobugs
 mobile/activation
+firefox-installer/.*


### PR DESCRIPTION
More generally I'm going to start filing PRs to add more entries to the allowlist, but this is a specific case that is important.