### PR TITLE
Expose a public interface to the schema generator script for testing

### DIFF
--- a/bin/schema_generator.sh
+++ b/bin/schema_generator.sh
@@ -17,9 +17,6 @@
 #   export MPS_SSH_KEY_BASE64=$(cat ~/.ssh/id_rsa | base64)
 #   make build && make run
 #
-# In a development environment, the script will default to a testing branch.
-# This can be changed by setting MPS_BRANCH_PUBLISH in the local shell.
-#
 # TODO: Update schema mapping for validation
 # TODO: Handle overwriting glean schemas
 # TODO: Include Main Ping from schema generation
@@ -29,7 +26,7 @@ set -exuo pipefail
 
 MPS_REPO_URL=${MPS_REPO_URL:-"git@github.com:mozilla-services/mozilla-pipeline-schemas.git"}
 MPS_BRANCH_SOURCE=${MPS_BRANCH_SOURCE:-"master"}
-MPS_BRANCH_PUBLISH=${MPS_BRANCH_PUBLISH:-"generated-schemas"}
+MPS_BRANCH_PUBLISH=${MPS_BRANCH_PUBLISH:-"test-generated-schemas"}
 
 MPS_BRANCH_WORKING="local-working-branch"
 MPS_SCHEMAS_DIR="schemas"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,4 @@ services:
       - MPS_SSH_KEY_BASE64
       - MPS_REPO_URL
       - MPS_BRANCH_SOURCE
-      - MPS_BRANCH_PUBLISH=test-generated-schemas
+      - MPS_BRANCH_PUBLISH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,6 @@ services:
     command: "true"
     environment:
       - MPS_SSH_KEY_BASE64
+      - MPS_REPO_URL
+      - MPS_BRANCH_SOURCE
+      - MPS_BRANCH_PUBLISH=test-generated-schemas


### PR DESCRIPTION
This exposes `MPS_REPO_URL`, `MPS_BRANCH_SOURCE`, and `MPS_BRANCH_PUBLISH` as a public interface to the container's main entry point. This also defaults the publish branch to `test-generated-schemas` when running the job locally. This prevents accidentally pushing to the production branch when testing locally. 

Fixes https://github.com/mozilla/mozilla-schema-generator/issues/28.