### PR TITLE
Add remaining telemetry pings

### DIFF
--- a/allowlist
+++ b/allowlist
@@ -12,7 +12,5 @@ org-mozilla-reference-browser/.*
 org-mozilla-samples-glean/.*
 org-mozilla-tv-firefox/.*
 pocket/.*
-telemetry/core
-telemetry/main
-telemetry/prio
+telemetry/.*
 webpagetest/.*


### PR DESCRIPTION
Requires https://github.com/mozilla-services/cloudops-infra/pull/1178

We may need to back this out again if the additional pings cause issues, but we're not expecting that to be the case.

Sync pings are still an open question but can hopefully be dealt with in a backwards-compatible manner from the [current placeholder schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/telemetry/sync/sync.4.schema.json).