### PR TITLE
Bump jsonschema-transpiler dependency to 1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV CARGO_INSTALL_ROOT=${HOME}/.cargo
 ENV PATH ${PATH}:${HOME}/.cargo/bin
 
 # Install a tagged version of jsonschema-transpiler
-RUN cargo install jsonschema-transpiler --version 1.2.0
+RUN cargo install jsonschema-transpiler --version 1.3.0
 
 # Upgrade pip
 RUN pip install --upgrade pip


### PR DESCRIPTION
This pulls in the new feature introduced in https://github.com/mozilla/jsonschema-transpiler/pull/82.