### PR TITLE
Enable all_pings for Glean

### DIFF
--- a/mozilla_schema_generator/main_ping.py
+++ b/mozilla_schema_generator/main_ping.py
@@ -41,11 +41,6 @@ class MainPing(GenericPing):
     def get_probes(self) -> List[MainProbe]:
         probes = self._get_json(self.probes_url)
 
-        for name, defn in probes.items():
-            history = [d for arr in defn["history"].values() for d in arr]
-            defn["history"] = sorted(history, key=lambda x: int(x["versions"]["first"]),
-                                     reverse=True)
-
         filtered = {
             pname: pdef for pname, pdef in probes.items()
             if "nightly" in pdef["first_added"]

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -7,11 +7,11 @@
 import yaml
 import pytest
 from .test_utils import print_and_test
-from mozilla_schema_generator import glean_ping, probes
+from mozilla_schema_generator import glean_ping
 from mozilla_schema_generator.config import Config
 from mozilla_schema_generator.utils import _get, prepend_properties
 
-from typing import List
+from typing import Dict, List
 
 
 @pytest.fixture
@@ -27,7 +27,7 @@ def config():
 
 
 class NoProbeGleanPing(glean_ping.GleanPing):
-    def get_probes(self) -> List[probes.GleanProbe]:
+    def _get_probe_defn_list(self) -> List[Dict]:
         return []
 
 

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -47,6 +47,9 @@ class TestGleanPing(object):
             assert "ping_info" in schema["properties"]
             assert "client_info" in schema["properties"]
 
+            labeled_counters = _get(schema, prepend_properties(("metrics", "labeled_counter")))
+            assert "glean.error.invalid_label" in labeled_counters['properties']
+
             if name == "baseline":
                 # Device should be included, since it's a standard metric
                 strings = _get(schema, prepend_properties(("metrics", "string")))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -191,8 +191,8 @@ class TestIntegration(object):
 
 
     def test_contains(self, schema, env, probes):  # noqa F811
-        probes["histogram/test_probe"]["history"][0]["arr"] = ["val1", "val2"]
-        probes["histogram/second_level_probe"]["history"][0]["arr"] = ["val2"]
+        probes["histogram/test_probe"]["history"]["nightly"][0]["arr"] = ["val1", "val2"]
+        probes["histogram/second_level_probe"]["history"]["nightly"][0]["arr"] = ["val2"]
 
         config = Config("default", {
             "top_level": {
@@ -219,12 +219,18 @@ class TestIntegration(object):
 
         for n in range(num_added_histograms):
             probes["histogram/{}".format(n)] = {
-                "history": [
-                    {
-                        "second_level": False,
-                        "details": {"keyed": False}
-                    }
-                ],
+                "history": {
+                    "nightly": [
+                        {
+                            "second_level": False,
+                            "details": {"keyed": False},
+                            "versions": {
+                                "first": "50",
+                                "last": "60",
+                            },
+                        }
+                    ]
+                },
                 "type": "histogram",
                 "name": str(n),
                 "first_added": {

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -26,19 +26,21 @@ class TestMatcher(object):
             'name': 'temp_name',
             'type': 'scalar',
             'first_added': {'nightly': '2019-01-01 00:00:00'},
-            'history': [{
-                'bug_numbers': [1522843],
-                'cpp_guard': None,
-                'description': 'Number of times any text content from the Changes panel is '
-                               'copied to the clipboard.\n',
-                'details': {'keyed': True, 'kind': 'uint', 'record_in_processes': ['main']},
-                'expiry_version': '69',
-                'notification_emails': ['dev-developer-tools@lists.mozilla.org'],
-                'optout': True,
-                'revisions': {'first': '4ab143dde4dc3424cfedc74b3648fbf2e47fb7bf',
-                              'last': '4ab143dde4dc3424cfedc74b3648fbf2e47fb7bf'},
-                'versions': {'first': '67', 'last': '67'}
-            }]
+            'history': {
+                'nightly': [{
+                    'bug_numbers': [1522843],
+                    'cpp_guard': None,
+                    'description': 'Number of times any text content from the Changes panel is '
+                                   'copied to the clipboard.\n',
+                    'details': {'keyed': True, 'kind': 'uint', 'record_in_processes': ['main']},
+                    'expiry_version': '69',
+                    'notification_emails': ['dev-developer-tools@lists.mozilla.org'],
+                    'optout': True,
+                    'revisions': {'first': '4ab143dde4dc3424cfedc74b3648fbf2e47fb7bf',
+                                  'last': '4ab143dde4dc3424cfedc74b3648fbf2e47fb7bf'},
+                    'versions': {'first': '67', 'last': '67'}
+                }]
+            }
         }
 
         matcher = Matcher(match_obj)
@@ -59,24 +61,26 @@ class TestMatcher(object):
             'name': 'test-name',
             'type': 'histogram',
             'first_added': {'nightly': '2019-02-02 02:02:00'},
-            'history': [{
-                'bug_numbers': [1351383],
-                'cpp_guard': None,
-                'description': 'Whether we have layed out any display:block containers with '
-                               'not-yet-supported properties from CSS Box Align.',
-                'details': {'high': 2,
-                            'keyed': False,
-                            'kind': 'boolean',
-                            'low': 1,
-                            'n_buckets': 3,
-                            'record_in_processes': ['main', 'content']},
-                'expiry_version': '57',
-                'notification_emails': ['bwerth@mozilla.com'],
-                'optout': True,
-                'revisions': {'first': 'f9605772a0c9098ed1bcaa98089b2c944ed69e9b',
-                              'last': '8e818b5e9b6bef0fc1a5c527ecf30b0d56a02f14'},
-                'versions': {'first': '55', 'last': '57'}
-            }]
+            'history': {
+                'nightly': [{
+                    'bug_numbers': [1351383],
+                    'cpp_guard': None,
+                    'description': 'Whether we have layed out any display:block containers with '
+                                   'not-yet-supported properties from CSS Box Align.',
+                    'details': {'high': 2,
+                                'keyed': False,
+                                'kind': 'boolean',
+                                'low': 1,
+                                'n_buckets': 3,
+                                'record_in_processes': ['main', 'content']},
+                    'expiry_version': '57',
+                    'notification_emails': ['bwerth@mozilla.com'],
+                    'optout': True,
+                    'revisions': {'first': 'f9605772a0c9098ed1bcaa98089b2c944ed69e9b',
+                                  'last': '8e818b5e9b6bef0fc1a5c527ecf30b0d56a02f14'},
+                    'versions': {'first': '55', 'last': '57'}
+                }]
+            }
         }
 
         matcher = Matcher(match_obj)
@@ -97,24 +101,26 @@ class TestMatcher(object):
             'name': 'test-name',
             'type': 'histogram',
             'first_added': {'nightly': '2019-02-02 02:02:00'},
-            'history': [{
-                'bug_numbers': [1351383],
-                'cpp_guard': None,
-                'description': 'Whether we have layed out any display:block containers with '
-                               'not-yet-supported properties from CSS Box Align.',
-                'details': {'high': 2,
-                            'keyed': False,
-                            'kind': 'boolean',
-                            'low': 1,
-                            'n_buckets': 3,
-                            'record_in_processes': ['main', 'content']},
-                'expiry_version': '57',
-                'notification_emails': ['bwerth@mozilla.com'],
-                'optout': True,
-                'revisions': {'first': 'f9605772a0c9098ed1bcaa98089b2c944ed69e9b',
-                              'last': '8e818b5e9b6bef0fc1a5c527ecf30b0d56a02f14'},
-                'versions': {'first': '55', 'last': '57'}
-            }]
+            'history': {
+                'nightly': [{
+                    'bug_numbers': [1351383],
+                    'cpp_guard': None,
+                    'description': 'Whether we have layed out any display:block containers with '
+                                   'not-yet-supported properties from CSS Box Align.',
+                    'details': {'high': 2,
+                                'keyed': False,
+                                'kind': 'boolean',
+                                'low': 1,
+                                'n_buckets': 3,
+                                'record_in_processes': ['main', 'content']},
+                    'expiry_version': '57',
+                    'notification_emails': ['bwerth@mozilla.com'],
+                    'optout': True,
+                    'revisions': {'first': 'f9605772a0c9098ed1bcaa98089b2c944ed69e9b',
+                                  'last': '8e818b5e9b6bef0fc1a5c527ecf30b0d56a02f14'},
+                    'versions': {'first': '55', 'last': '57'}
+                }]
+            }
         }
 
         matcher = Matcher(match_obj)
@@ -122,7 +128,7 @@ class TestMatcher(object):
 
         assert not matcher.matches(probe)
 
-        probe_defn['history'][0]['expiry_version'] = '58'
+        probe_defn['history']['nightly'][0]['expiry_version'] = '58'
         assert matcher.matches(probe)
 
     def test_not_and_contains(self):

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+from mozilla_schema_generator.probes import GleanProbe, MainProbe
+
+
+@pytest.fixture
+def glean_probe_defn():
+    return {
+        "history": [
+            {
+                "dates": {
+                    "first": "2019-04-12 13:44:13",
+                    "last": "2019-08-08 15:34:03",
+                },
+                "send_in_pings": [
+                    "metrics",
+                ],
+            },
+            {
+                "dates": {
+                    "first": "2019-08-08 15:34:14",
+                    "last": "2019-08-08 15:45:14",
+                },
+                "send_in_pings": [
+                    "all_pings",
+                ],
+            }
+        ],
+        "name": "glean.error.invalid_value",
+        "type": "labeled_counter",
+    }
+
+
+@pytest.fixture
+def main_probe_defn():
+    return {
+        "first_added": {
+            "beta": "2017-08-07 23:34:15",
+            "nightly": "2017-06-21 11:42:18",
+            "release": "2017-09-19 01:26:22"
+        },
+        "history": {
+            "beta": [
+                {
+                    "details": {
+                        "keyed": False,
+                        "kind": "string",
+                    },
+                    "versions": {
+                        "first": "66",
+                        "last": "69"
+                    }
+                },
+                {
+                    "details": {
+                        "keyed": False,
+                        "kind": "string",
+                    },
+                    "versions": {
+                        "first": "61",
+                        "last": "65"
+                    }
+                },
+                {
+                    "details": {
+                        "keyed": False,
+                        "kind": "string",
+                    },
+                    "versions": {
+                        "first": "55",
+                        "last": "60"
+                    }
+                }
+            ],
+            "nightly": [
+                {
+                    "details": {
+                        "keyed": False,
+                        "kind": "string",
+                    },
+                    "versions": {
+                        "first": "62",
+                        "last": "66"
+                    }
+                },
+                {
+                    "details": {
+                        "keyed": False,
+                        "kind": "string",
+                    },
+                    "versions": {
+                        "first": "67",
+                        "last": "70"
+                    }
+                },
+                {
+                    "details": {
+                        "keyed": False,
+                        "kind": "string",
+                    },
+                    "versions": {
+                        "first": "56",
+                        "last": "61"
+                    }
+                }
+            ],
+            "release": [
+                {
+                    "details": {
+                        "keyed": False,
+                        "kind": "string",
+                    },
+                    "versions": {
+                        "first": "65",
+                        "last": "68"
+                    }
+                },
+                {
+                    "details": {
+                        "keyed": False,
+                        "kind": "string",
+                    },
+                    "versions": {
+                        "first": "61",
+                        "last": "64"
+                    }
+                },
+                {
+                    "details": {
+                        "keyed": False,
+                        "kind": "string",
+                    },
+                    "versions": {
+                        "first": "55",
+                        "last": "60"
+                    }
+                }
+            ]
+        },
+        "name": "a11y.instantiators",
+        "type": "scalar"
+    }
+
+
+class TestProbe(object):
+
+    def test_glean_sort(self, glean_probe_defn):
+        probe = GleanProbe("scalar/test_probe", glean_probe_defn, pings=["aping"])
+        assert probe.definition == glean_probe_defn["history"][1]
+
+    def test_glean_all_pings(self, glean_probe_defn):
+        pings = ["ping1", "ping2", "ping3"]
+        probe = GleanProbe("scalar/test_probe", glean_probe_defn, pings=pings)
+        assert probe.definition["send_in_pings"] == pings
+
+    def test_main_sort(self, main_probe_defn):
+        probe = MainProbe("scalar/test_probe", main_probe_defn)
+        assert probe.definition == main_probe_defn["history"]["nightly"][1]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,13 +68,19 @@ def probes():
             "first_added": {
                 "nightly": "2019-01-02 00:00:00"
             },
-            "history": [
-                {
-                    "description": "Remember the Canterbury",
-                    "second_level": True,
-                    "details": {"keyed": False}
-                }
-            ]
+            "history": {
+                'nightly': [
+                    {
+                        "description": "Remember the Canterbury",
+                        "second_level": True,
+                        "details": {"keyed": False},
+                        "versions": {
+                            "first": "50",
+                            "last": "60",
+                        },
+                    }
+                ]
+            }
         },
         "histogram/test_probe": {
             "name": "test_probe",
@@ -82,13 +88,19 @@ def probes():
             "first_added": {
                 "nightly": "2019-01-01 00:00:00"
             },
-            "history": [
-                {
-                    "description": "Remember the Canterbury",
-                    "second_level": False,
-                    "details": {"keyed": False}
-                }
-            ]
+            "history": {
+                'nightly': [
+                    {
+                        "description": "Remember the Canterbury",
+                        "second_level": False,
+                        "details": {"keyed": False},
+                        "versions": {
+                            "first": "50",
+                            "last": "60",
+                        },
+                    }
+                ]
+            }
         }
     }
 


### PR DESCRIPTION
- Allows `all_pings` for a Glean probe definition, where
  the metric is added to every ping for that app
- Correctly sorts the Glean probe definitions by date
- Move sorting of Main probes to the MainProbe class
- Update tests to fix new schema for Main probe defs
  (it now matches the probe-info-service exactly)