### PR TITLE
Generate BQ schemas for fenix-nightly

### DIFF
--- a/allowlist
+++ b/allowlist
@@ -8,6 +8,7 @@ mobile/.*
 mozdata/.*
 mozza/.*
 org-mozilla-fenix/.*
+org-mozilla-fenix-nightly/.*
 org-mozilla-reference-browser/.*
 org-mozilla-samples-glean/.*
 org-mozilla-tv-firefox/.*


### PR DESCRIPTION
Should this be considered prod as well? Currently these will be routed to stage because they are a different namespace (we're moving everything to prod soonish so it perhaps won't be as relevant).