### PR TITLE
Add support for schema aliasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ dist
 build
 eggs
 parts
-bin
 var
 sdist
 develop-eggs

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ lint:
 
 test:
 	py.test
+	jsonschema -i aliases.json validation-schemas/aliases.json
 
 coverage:
 	pytest tests/ --cov=mozilla_schema_generator

--- a/aliases.json
+++ b/aliases.json
@@ -1,12 +1,12 @@
 {
   "telemetry": {
     "saved-session": {
-      "src-namespace": "telemetry",
-      "src-doctype": "main"
+      "source-namespace": "telemetry",
+      "source-doctype": "main"
     },
     "first-shutdown": {
-      "src-namespace": "telemetry",
-      "src-doctype": "main"
+      "source-namespace": "telemetry",
+      "source-doctype": "main"
     }
   }
 }

--- a/aliases.json
+++ b/aliases.json
@@ -1,0 +1,12 @@
+{
+  "telemetry": {
+    "saved-session": {
+      "src-namespace": "telemetry",
+      "src-doctype": "main"
+    },
+    "first-shutdown": {
+      "src-namespace": "telemetry",
+      "src-doctype": "main"
+    }
+  }
+}

--- a/bin/alias_schemas
+++ b/bin/alias_schemas
@@ -57,7 +57,7 @@ def main(aliases_path, base_dir):
                 fname = source.name.replace(source_doctype, dest_doctype)
                 dest = dest_dir / fname
 
-                print("Aliasing {} to {}".format(dest, source))
+                print(f"Aliasing {dest} to {source}")
 
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy(source, dest)

--- a/bin/alias_schemas
+++ b/bin/alias_schemas
@@ -33,14 +33,15 @@ def main(aliases_path, base_dir):
     with open(aliases_path) as f:
         aliases_parsed = json.load(f)
 
-    for dest_ns, doctypes in aliases_parsed.items():
-        for dest_dt, alias_info in doctypes.items():
-            source_ns = alias_info['src-namespace']
-            source_dt = alias_info['src-doctype']
-            source_dir = base_dir / source_ns / source_dt
-            dest_dir = base_dir / dest_ns / dest_dt 
+    for dest_namespace, doctypes in aliases_parsed.items():
+        for dest_doctype, alias_info in doctypes.items():
+            source_namespace = alias_info['source-namespace']
+            source_doctype = alias_info['source-doctype']
+            source_dir = base_dir / source_namespace / source_doctype
+            dest_dir = base_dir / dest_namespace / dest_doctype
+
             for source in source_dir.glob('*'):
-                fname = source.name.replace(source_dt, dest_dt)
+                fname = source.name.replace(source_doctype, dest_doctype)
                 dest = dest_dir / fname
 
                 print("Aliasing {} to {}".format(dest, source))

--- a/bin/alias_schemas
+++ b/bin/alias_schemas
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import click
+import json 
+import pathlib
+import shutil
+
+
+@click.command()
+@click.argument(
+    'aliases-path',
+    type=click.Path(
+        dir_okay=False,
+        file_okay=True,
+        writable=False,
+        exists=True,
+    ),
+    required=True
+)
+@click.argument(
+    'base-dir',
+    type=click.Path(
+        dir_okay=True,
+        file_okay=False,
+        writable=True,
+        exists=True,
+    ),
+    required=True
+)
+def main(aliases_path, base_dir):
+    base_dir = pathlib.Path(base_dir)
+
+    with open(aliases_path) as f:
+        aliases_parsed = json.load(f)
+
+    for dest_ns, doctypes in aliases_parsed.items():
+        for dest_dt, alias_info in doctypes.items():
+            source_ns = alias_info['src-namespace']
+            source_dt = alias_info['src-doctype']
+            source_dir = base_dir / source_ns / source_dt
+            dest_dir = base_dir / dest_ns / dest_dt 
+            for source in source_dir.glob('*'):
+                fname = source.name.replace(source_dt, dest_dt)
+                dest = dest_dir / fname
+
+                print("Aliasing {} to {}".format(dest, source))
+                shutil.copy(source, dest)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/alias_schemas
+++ b/bin/alias_schemas
@@ -4,6 +4,14 @@ import click
 import json 
 import pathlib
 import shutil
+import jsonschema
+
+
+SCHEMA_PATH = pathlib.Path(__file__).parent.parent / "validation-schemas" / "aliases.json"
+
+def get_schema():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
 
 
 @click.command()
@@ -28,10 +36,13 @@ import shutil
     required=True
 )
 def main(aliases_path, base_dir):
+
     base_dir = pathlib.Path(base_dir)
 
     with open(aliases_path) as f:
         aliases_parsed = json.load(f)
+
+    jsonschema.validate(instance=aliases_parsed, schema=get_schema())
 
     for dest_namespace, doctypes in aliases_parsed.items():
         for dest_doctype, alias_info in doctypes.items():
@@ -40,11 +51,15 @@ def main(aliases_path, base_dir):
             source_dir = base_dir / source_namespace / source_doctype
             dest_dir = base_dir / dest_namespace / dest_doctype
 
+            assert source_dir.exists()
+
             for source in source_dir.glob('*'):
                 fname = source.name.replace(source_doctype, dest_doctype)
                 dest = dest_dir / fname
 
                 print("Aliasing {} to {}".format(dest, source))
+
+                dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy(source, dest)
 
 

--- a/bin/schema_generator.sh
+++ b/bin/schema_generator.sh
@@ -32,6 +32,7 @@ MPS_BRANCH_WORKING="local-working-branch"
 MPS_SCHEMAS_DIR="schemas"
 BASE_DIR="/app"
 DISALLOWLIST="$BASE_DIR/mozilla-schema-generator/disallowlist"
+ALIASES_PATH="$BASE_DIR/mozilla-schema-generator/aliases.json"
 
 
 function setup_git_ssh() {
@@ -155,6 +156,9 @@ function main() {
 
     # Keep only allowed schemas
     filter_schemas
+
+    # Add schema aliases
+    alias_schemas $ALIASES_PATH .
 
     # Push to branch of MPS
     cd ../

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -3,3 +3,4 @@ flake8==3.7.7
 pytest-cov==2.6.1
 pytest==4.3.1
 twine==1.13.0
+jsonschema==3.0.2

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ readme = open('README.md').read()
 
 setup(
     name='mozilla-schema-generator',
+    python_requires='>=3.6.0',
     version='0.1.3',
     description='Create full representations of schemas using the probe info service.',
     long_description=readme,

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Tests for `mozilla-schema-generator` scripts.
+"""
+
+import json
+import pathlib
+import shutil
+import subprocess
+import pytest
+
+
+class TestSchemaAliasing(object):
+
+    base_dir = "./test-schemas"
+    test_aliases_path = "test-aliases.json"
+    source_namespace = "namespace"
+    source_doctype = "doctype"
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown_dir(self):
+        dir_path = pathlib.Path(self.base_dir)
+        path = dir_path / self.source_namespace / self.source_doctype
+        json_file = path / f"{self.source_doctype}.1.schema.json"
+        bq_file = path / f"{self.source_doctype}.1.bq"
+
+        json_file.parent.mkdir(parents=True)
+        json_file.touch()
+        bq_file.touch()
+
+        yield
+
+        shutil.rmtree(dir_path)
+        pathlib.Path(self.test_aliases_path).unlink()
+
+    def write_aliases(self, aliases):
+        path = pathlib.Path(self.test_aliases_path)
+        with open(path, 'w') as f:
+            json.dump(aliases, f)
+
+        return path
+
+    def test_aliasing_same_namespace(self):
+        test_doctype = "test-doctype"
+        aliases_path = self.write_aliases({
+            self.source_namespace: {
+                test_doctype: {
+                    "source-namespace": self.source_namespace,
+                    "source-doctype": self.source_doctype
+                }
+            }
+        })
+
+        res = subprocess.run(("./bin/alias_schemas", str(aliases_path), self.base_dir))
+
+        assert res.returncode == 0
+
+        test_path = pathlib.Path(self.base_dir) / self.source_namespace / test_doctype 
+        assert (test_path / f"{test_doctype}.1.schema.json").exists()
+        assert (test_path / f"{test_doctype}.1.bq").exists()
+
+    def test_aliasing_new_namespace(self):
+        test_namespace = "test-namespace"
+        test_doctype = "test-doctype"
+        aliases_path = self.write_aliases({
+            test_namespace: {
+                test_doctype: {
+                    "source-namespace": self.source_namespace,
+                    "source-doctype": self.source_doctype
+                }
+            }
+        })
+
+        res = subprocess.run(("./bin/alias_schemas", str(aliases_path), self.base_dir))
+
+        assert res.returncode == 0
+
+        test_path = pathlib.Path(self.base_dir) / test_namespace / test_doctype 
+        assert (test_path / f"{test_doctype}.1.schema.json").exists()
+        assert (test_path / f"{test_doctype}.1.bq").exists()
+
+    def test_no_aliasing(self):
+        aliases_path = self.write_aliases({})
+        res = subprocess.run(("./bin/alias_schemas", str(aliases_path), self.base_dir))
+
+        assert res.returncode == 0
+
+        # should only have bq and json schema for source
+        test_path = pathlib.Path(self.base_dir)
+        assert len(list(test_path.iterdir())) == 1
+        assert len(list((test_path / self.source_namespace).iterdir())) == 1
+        assert len(list((test_path / self.source_namespace / self.source_doctype).iterdir())) == 2
+
+    def test_missing_source_errors(self):
+        test_namespace = "test-namespace"
+        test_doctype = "test-doctype"
+        aliases_path = self.write_aliases({
+            test_namespace: {
+                test_doctype: {
+                    "source-namespace": "missing-namespace",
+                    "source-doctype": self.source_doctype
+                }
+            }
+        })
+
+        res = subprocess.run(("./bin/alias_schemas", str(aliases_path), self.base_dir))
+
+        assert res.returncode != 0
+
+    def test_improper_name_errors(self):
+        test_namespace = "@test-namespace"
+        test_doctype = "test-doctype"
+        aliases_path = self.write_aliases({
+            test_namespace: {
+                test_doctype: {
+                    "source-namespace": "missing-namespace",
+                    "source-doctype": self.source_doctype
+                }
+            }
+        })
+
+        res = subprocess.run(("./bin/alias_schemas", str(aliases_path), self.base_dir))
+        assert res.returncode != 0

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -60,7 +60,7 @@ class TestSchemaAliasing(object):
 
         assert res.returncode == 0
 
-        test_path = pathlib.Path(self.base_dir) / self.source_namespace / test_doctype 
+        test_path = pathlib.Path(self.base_dir) / self.source_namespace / test_doctype
         assert (test_path / f"{test_doctype}.1.schema.json").exists()
         assert (test_path / f"{test_doctype}.1.bq").exists()
 
@@ -80,7 +80,7 @@ class TestSchemaAliasing(object):
 
         assert res.returncode == 0
 
-        test_path = pathlib.Path(self.base_dir) / test_namespace / test_doctype 
+        test_path = pathlib.Path(self.base_dir) / test_namespace / test_doctype
         assert (test_path / f"{test_doctype}.1.schema.json").exists()
         assert (test_path / f"{test_doctype}.1.bq").exists()
 

--- a/validation-schemas/aliases.json
+++ b/validation-schemas/aliases.json
@@ -7,16 +7,16 @@
         "[a-zA-Z_-]": {
           "type": "object",
           "properties": {
-            "src-namespace": {
+            "source-namespace": {
               "type": "string"
             },
-            "src-doctype": {
+            "source-doctype": {
               "type": "string"
             }
           },
           "required": [
-            "src-namespace",
-            "src-doctype"
+            "source-namespace",
+            "source-doctype"
           ],
           "additionalProperties": false
         }

--- a/validation-schemas/aliases.json
+++ b/validation-schemas/aliases.json
@@ -20,7 +20,8 @@
           ],
           "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/validation-schemas/aliases.json
+++ b/validation-schemas/aliases.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "patternProperties": {
+    "[a-zA-Z_-]": {
+      "type": "object",
+      "patternProperties": {
+        "[a-zA-Z_-]": {
+          "type": "object",
+          "properties": {
+            "src-namespace": {
+              "type": "string"
+            },
+            "src-doctype": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "src-namespace",
+            "src-doctype"
+          ],
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Resolves #53, for both saved-session and first-shutdown.

This adds a new file which lists the schemas we want to alias.
This does not handle versions; the aliased namespace/doctype
are assumed to have the same versions as the source schemas.

This also includes a validation schema for the aliasing file,
and tests that the file is valid.

The test output is here: https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/test-generated-schemas