### PR TITLE
Move jsonschema requirement

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,3 +2,4 @@ click==7.0
 pyyaml==4.2b1
 requests==2.21.0
 wheel>=0.22
+jsonschema==3.0.2

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -3,4 +3,3 @@ flake8==3.7.7
 pytest-cov==2.6.1
 pytest==4.3.1
 twine==1.13.0
-jsonschema==3.0.2


### PR DESCRIPTION
I re-ran MSG from airflow and it looks like only test requirements were updated for jsonschema. See [the log](https://workflow.telemetry.mozilla.org/log?task_id=mozilla_schema_generator&dag_id=probe_scraper&execution_date=2019-08-14T00%3A00%3A00%2B00%3A00).