### PR TITLE
Include any pings a probe has reported

### DIFF
--- a/mozilla_schema_generator/matcher.py
+++ b/mozilla_schema_generator/matcher.py
@@ -64,6 +64,9 @@ class Matcher(object):
 
     @staticmethod
     def _matches(match_v: Any, probe_v: Any) -> bool:
+        if isinstance(probe_v, set):
+            probe_v = list(probe_v)
+
         if probe_v is None:
             return False
 

--- a/mozilla_schema_generator/probes.py
+++ b/mozilla_schema_generator/probes.py
@@ -116,7 +116,8 @@ class GleanProbe(Probe):
         self._set_definition(definition)
         super().__init__(identifier, definition)
 
-        defn_pings = set([p for d in definition[self.history_key] for p in d.get("send_in_pings", ["metrics"])])
+        defn_pings = set([p for d in definition[self.history_key]
+                          for p in d.get("send_in_pings", ["metrics"])])
         self.definition["send_in_pings"] = defn_pings
 
         if pings is not None:

--- a/mozilla_schema_generator/probes.py
+++ b/mozilla_schema_generator/probes.py
@@ -116,12 +116,15 @@ class GleanProbe(Probe):
         self._set_definition(definition)
         super().__init__(identifier, definition)
 
+        defn_pings = set([p for d in definition[self.history_key] for p in d.get("send_in_pings", ["metrics"])])
+        self.definition["send_in_pings"] = defn_pings
+
         if pings is not None:
             self._update_all_pings(pings)
 
     def _update_all_pings(self, pings: List[str]):
         if GleanProbe.all_pings_keyword in self.definition["send_in_pings"]:
-            self.definition["send_in_pings"] = pings
+            self.definition["send_in_pings"] = set(pings)
 
     def _set_definition(self, full_defn: dict):
         self.definition = max(full_defn[self.history_key],

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -37,6 +37,34 @@ def glean_probe_defn():
 
 
 @pytest.fixture
+def glean_probe_defn_subset_pings():
+    return {
+        "history": [
+            {
+                "dates": {
+                    "first": "2019-04-12 13:44:13",
+                    "last": "2019-08-08 15:34:03",
+                },
+                "send_in_pings": [
+                    "metrics",
+                ],
+            },
+            {
+                "dates": {
+                    "first": "2019-08-08 15:34:14",
+                    "last": "2019-08-08 15:45:14",
+                },
+                "send_in_pings": [
+                    "baseline",
+                ],
+            }
+        ],
+        "name": "glean.error.invalid_value",
+        "type": "labeled_counter",
+    }
+
+
+@pytest.fixture
 def main_probe_defn():
     return {
         "first_added": {
@@ -163,7 +191,12 @@ class TestProbe(object):
     def test_glean_all_pings(self, glean_probe_defn):
         pings = ["ping1", "ping2", "ping3"]
         probe = GleanProbe("scalar/test_probe", glean_probe_defn, pings=pings)
-        assert probe.definition["send_in_pings"] == pings
+        assert probe.definition["send_in_pings"] == set(pings)
+
+    def test_glean_subset_of_pings(self, glean_probe_defn_subset_pings):
+        pings = ["ping1", "ping2", "ping3"]
+        probe = GleanProbe("scalar/test_probe", glean_probe_defn_subset_pings, pings=pings)
+        assert probe.definition["send_in_pings"] == {"baseline", "metrics"}
 
     def test_main_sort(self, main_probe_defn):
         probe = MainProbe("scalar/test_probe", main_probe_defn)


### PR DESCRIPTION
Run here: https://github.com/fbertsch/mozilla-pipeline-schemas/blob/612c4811de3702f93affe6f446b43089620ddc4c/schemas/org-mozilla-fenix/metrics/metrics.1.bq

Looks like it adds the counters back in.