### PR TITLE
Add --tuple-struct to schema generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV CARGO_INSTALL_ROOT=${HOME}/.cargo
 ENV PATH ${PATH}:${HOME}/.cargo/bin
 
 # Install a tagged version of jsonschema-transpiler
-RUN cargo install jsonschema-transpiler --version 1.4.1
+RUN cargo install jsonschema-transpiler --version 1.5.0
 
 # Upgrade pip
 RUN pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV CARGO_INSTALL_ROOT=${HOME}/.cargo
 ENV PATH ${PATH}:${HOME}/.cargo/bin
 
 # Install a tagged version of jsonschema-transpiler
-RUN cargo install jsonschema-transpiler --version 1.5.0
+RUN cargo install jsonschema-transpiler --version 1.6.0
 
 # Upgrade pip
 RUN pip install --upgrade pip

--- a/bin/schema_generator.sh
+++ b/bin/schema_generator.sh
@@ -140,6 +140,7 @@ function main() {
             --type bigquery \
             --normalize-case \
             --force-nullable \
+            --tuple-struct \
                 "$fname" > "$bq_out"
     done
 


### PR DESCRIPTION
My understanding is that this can roll out independently from https://github.com/mozilla/gcp-ingestion/pull/847. The probe scraper dag is running now so perhaps we should merge+deploy this tomorrow.