### PR TITLE
Fix kebab-cased all-pings

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -27,7 +27,7 @@ class GleanPing(GenericPing):
 
     default_dependencies = ['glean']
     default_pings = {"baseline", "events", "metrics"}
-    ignore_pings = {"all_pings", "default", "glean_ping_info", "glean_client_info"}
+    ignore_pings = {"all-pings", "default", "glean_ping_info", "glean_client_info"}
 
     def __init__(self, repo):  # TODO: Make env-url optional
         self.repo = repo

--- a/mozilla_schema_generator/probes.py
+++ b/mozilla_schema_generator/probes.py
@@ -125,7 +125,7 @@ class MainProbe(Probe):
 
 class GleanProbe(Probe):
 
-    all_pings_keyword = "all_pings"
+    all_pings_keyword = "all-pings"
     first_added_key = "first_added"
 
     def __init__(self, identifier: str, definition: dict, *, pings: List[str] = None):

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -27,7 +27,7 @@ def glean_probe_defn():
                     "last": "2019-08-08 15:45:14",
                 },
                 "send_in_pings": [
-                    "all_pings",
+                    "all-pings",
                 ],
             }
         ],


### PR DESCRIPTION
Looks like the switch to kebab-case broke the schema-generator:

- It's added a ping `all-pings`, which used to be a snake-cased `all_pings` which indicated to send a metric in every ping
- It's removed a few core glean fields, but that's related to the above because it's any of the ones with `all-pings`

This fixes those.