### PR TITLE
Allow historic version of all_pings

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -27,7 +27,7 @@ class GleanPing(GenericPing):
 
     default_dependencies = ['glean']
     default_pings = {"baseline", "events", "metrics"}
-    ignore_pings = {"all-pings", "default", "glean_ping_info", "glean_client_info"}
+    ignore_pings = {"all-pings", "all_pings", "default", "glean_ping_info", "glean_client_info"}
 
     def __init__(self, repo):  # TODO: Make env-url optional
         self.repo = repo

--- a/mozilla_schema_generator/probes.py
+++ b/mozilla_schema_generator/probes.py
@@ -125,7 +125,7 @@ class MainProbe(Probe):
 
 class GleanProbe(Probe):
 
-    all_pings_keyword = "all-pings"
+    all_pings_keywords = ("all-pings", "all_pings")
     first_added_key = "first_added"
 
     def __init__(self, identifier: str, definition: dict, *, pings: List[str] = None):
@@ -141,7 +141,7 @@ class GleanProbe(Probe):
             self._update_all_pings(pings)
 
     def _update_all_pings(self, pings: List[str]):
-        if GleanProbe.all_pings_keyword in self.definition["send_in_pings"]:
+        if any([kw in self.definition["send_in_pings"] for kw in GleanProbe.all_pings_keywords]):
             self.definition["send_in_pings"] = set(pings)
 
     def _set_definition(self, full_defn: dict):


### PR DESCRIPTION
We updated all_pings to all-pings, but historically we still
have all_pings. We need to allow these values.

Good thing we have a retro tomorrow 🤦‍♀ 