### PR TITLE
Add individual commit information into auto-pushed commits

### DIFF
--- a/bin/schema_generator.sh
+++ b/bin/schema_generator.sh
@@ -91,7 +91,7 @@ function filter_schemas() {
     find . -name '*.bq' | grep -f $DISALLOWLIST | xargs rm -f
 }
 
-function commit_schemas() {
+function commit_and_push_schemas() {
     # This method will keep a changelog of releases. If we delete and newly
     # checkout branches everytime, that will contain a changelog of changes.
     # Assumes the current directory is the root of the repository
@@ -110,6 +110,7 @@ function commit_schemas() {
     find . -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
     git checkout $MPS_BRANCH_WORKING -- schemas
     git commit -a -m "Auto-push from schema generation [ci skip]" || echo "Nothing to commit"
+    git push
 }
 
 function main() {
@@ -156,8 +157,7 @@ function main() {
 
     # Push to branch of MPS
     cd ../
-    commit_schemas
-    git push
+    commit_and_push_schemas
 }
 
 main "$@"

--- a/bin/schema_generator.sh
+++ b/bin/schema_generator.sh
@@ -16,11 +16,6 @@
 # Example usage:
 #   export MPS_SSH_KEY_BASE64=$(cat ~/.ssh/id_rsa | base64)
 #   make build && make run
-#
-# TODO: Update schema mapping for validation
-# TODO: Handle overwriting glean schemas
-# TODO: Include Main Ping from schema generation
-# TODO: What the heck to do with pioneer-study, a non-nested namespace
 
 set -exuo pipefail
 

--- a/bin/schema_generator.sh
+++ b/bin/schema_generator.sh
@@ -106,7 +106,7 @@ function create_changelog() {
         --date=iso
 }
 
-function commit_and_push_schemas() {
+function commit_schemas() {
     # This method will keep a changelog of releases. If we delete and newly
     # checkout branches everytime, that will contain a changelog of changes.
     # Assumes the current directory is the root of the repository
@@ -128,7 +128,6 @@ function commit_and_push_schemas() {
         --message "Auto-push from schema generation [ci skip]" \
         --message "$(create_changelog)" \
         || echo "Nothing to commit"
-    git push || git push --set-upstream origin "$MPS_BRANCH_PUBLISH"
 }
 
 function main() {
@@ -175,7 +174,8 @@ function main() {
 
     # Push to branch of MPS
     cd ../
-    commit_and_push_schemas
+    commit_schemas
+    git push || git push --set-upstream origin "$MPS_BRANCH_PUBLISH"
 }
 
 main "$@"

--- a/bin/schema_generator.sh
+++ b/bin/schema_generator.sh
@@ -103,8 +103,7 @@ function create_changelog() {
     git log "${MPS_BRANCH_SOURCE}" \
         --since="$start_date" \
         --pretty=format:"%h%x09%cd%x09%s" \
-        --date=iso \
-        | cat
+        --date=iso
 }
 
 function commit_and_push_schemas() {

--- a/bin/schema_generator.sh
+++ b/bin/schema_generator.sh
@@ -55,6 +55,10 @@ function setup_git_ssh() {
     chown -R "$(id -u):$(id -g)" "$HOME/.ssh"
     chmod 700 "$HOME/.ssh"
     chmod 700 "$HOME/.ssh/id_ed25519"
+
+    # add private key to the ssh agent to prompt for password once
+    eval "$(ssh-agent)"
+    ssh-add
 }
 
 function clone_and_configure_mps() {

--- a/tests/test_commit_changelog.sh
+++ b/tests/test_commit_changelog.sh
@@ -42,7 +42,7 @@ bin/schema_generator.sh
 pushd ${MPS_GIT_PATH}
 git checkout ${MPS_BRANCH_PUBLISH}
 GIT_COMMITTER_DATE=$(git log ${initial_commit} -1 --pretty=%cd --date=iso) \
-    git commit --amend
+    git commit --amend --no-edit
 # now the commit hash has changed, so we must force push
 git push -f
 popd

--- a/tests/test_commit_changelog.sh
+++ b/tests/test_commit_changelog.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # A script for testing the functionality of changelog information in generated
-# schemas. The output of the this command must be checked manually, and this
+# schemas. The output of this command must be checked manually, and this
 # script must be configured to commit with your identity.
 
 # To run this script, copy and paste the commands in the heredoc into your shell

--- a/tests/test_commit_changelog.sh
+++ b/tests/test_commit_changelog.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# A script for testing the functionality of changelog information in generated
+# schemas. The output of the this command must be checked manually, and this
+# script must be configured to commit with your identity.
+
+# To run this script, copy and paste the commands in the heredoc into your shell
+: << EOF
+export MPS_SSH_KEY_BASE64=$(cat ~/.ssh/id_rsa | base64)
+
+make build && \
+docker-compose run --entrypoint /bin/bash app \
+    mozilla-schema-generator/tests/test_commit_changelog.sh
+EOF
+
+set -exuo pipefail
+
+# 2020-01-07 to 2020-01-08, chosen due to the number of commits
+initial_commit=f28259d4d6995a5af8ec3d850dc432a43baca906
+last_commit=b69699673bf01df9d357bd3e2f4dbde9fe6ec726
+
+# $ git log f28259d...b696996 --oneline
+# b696996 Make the $id for main ping schema show version as "4"
+# a56043b Add page for china build to activity stream impression_stats
+# 6b9c323 Allow negative sessionLengths and event timestamps
+# 29b042f Allow for old-style ping_type in glean
+# d093483 Add changelog entry
+# dc87e27 Make glean ping_type kebab
+
+export MPS_SSH_KEY_BASE64=${MPS_SSH_KEY_BASE64?key must be set}
+export MPS_BRANCH_SOURCE=${initial_commit}
+export MPS_BRANCH_PUBLISH="test-generated-schemas-changelog"
+MPS_GIT_PATH=/app/mozilla-pipeline-schemas
+
+# initialize the testing branch using the generator script
+cd "$(dirname "$0")/.."
+bin/schema_generator.sh
+
+# now, update the timestamp of the commit to be the same as the initial commit
+# https://stackoverflow.com/questions/454734/how-can-one-change-the-timestamp-of-an-old-commit-in-git
+
+# directory is derived from logic in schema_generator
+pushd ${MPS_GIT_PATH}
+git checkout ${MPS_BRANCH_PUBLISH}
+GIT_COMMITTER_DATE=$(git log ${initial_commit} -1 --pretty=%cd --date=iso) \
+    git commit --amend
+# now the commit hash has changed, so we must force push
+git push -f
+popd
+
+# run the generator again and check the log
+export MPS_BRANCH_SOURCE=${last_commit}
+bin/schema_generator.sh
+
+# check the results
+pushd ${MPS_GIT_PATH}
+git log ${MPS_BRANCH_PUBLISH} -1


### PR DESCRIPTION
This fixes #20 by adding log information of commits between the last generated commit and the present. This works by looking at the last commit date in the generated-schemas branch, and filtering out the commits in the master branch using the `--since` flag. This works best when all commits are added via squash/rebase, so I've disabled merge commits in mozilla-pipeline-schemas. This is easy to revert if undesirable.

The test associated test generates the following branch in mozilla-pipeline-schemas: https://github.com/mozilla-services/mozilla-pipeline-schemas/commits/test-generated-schemas-changelog

```
 Auto-push from schema generation [ci skip]

b696996	2020-01-08 12:51:40 -0500	Make the $id for main ping schema show version as "4"
a56043b	2020-01-08 11:54:56 -0500	Add page for china build to activity stream impression_stats
6b9c323	2020-01-08 10:39:36 -0500	Allow negative sessionLengths and event timestamps
29b042f	2020-01-08 10:26:59 -0500	Allow for old-style ping_type in glean
d093483	2020-01-08 10:26:59 -0500	Add changelog entry
dc87e27	2020-01-08 10:26:59 -0500	Make glean ping_type kebab
f28259d	2020-01-07 15:58:25 -0800	Revert "Add build/ folder to gitignore"
```

There are some quirks around how we handle git management within the container that I think are undesirable. First, every run of `schema_generator.sh` will clobber/delete the state of the previous run, which requires typing in the password for your ssh key to push to the repo. There are also protected files in the checked out repo that will require user prompting in the script. One idea is to prepopulate this repo with a submodule pointing to mozilla-pipeline-schemas, like mozilla-services/edge-validator, or to modifying the `setup_git_ssh` and `clone_and_configure_mps` functions so they can be run without throwing away all the initialization. This would make it easier to generate diffs between versions of the repo or revisions of mps. 

Additionally, we might want to think about adding tags to the master branch that correspond to a generated schema. This could be used as an alternative landmark to commit date for determining the date range for the autocommit comment. 