### PR TITLE
Bump jsonschema-transpiler to v1.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV CARGO_INSTALL_ROOT=${HOME}/.cargo
 ENV PATH ${PATH}:${HOME}/.cargo/bin
 
 # Install a tagged version of jsonschema-transpiler
-RUN cargo install jsonschema-transpiler --version 1.6.0
+RUN cargo install jsonschema-transpiler --version 1.8.0
 
 # Upgrade pip
 RUN pip install --upgrade pip


### PR DESCRIPTION
Adds descriptions to schemas as per https://github.com/mozilla/jsonschema-transpiler/releases/tag/v1.8.0