### PR TITLE
Bug 1597782 -Collect GPU process histograms correctly

### DIFF
--- a/mozilla_schema_generator/configs/main.yaml
+++ b/mozilla_schema_generator/configs/main.yaml
@@ -75,7 +75,7 @@ payload:
           table_group: histograms
           type: histogram
           details:
-            keyed: true
+            keyed: false
             record_in_processes:
               contains: gpu
       keyedHistograms:

--- a/mozilla_schema_generator/configs/main.yaml
+++ b/mozilla_schema_generator/configs/main.yaml
@@ -41,7 +41,7 @@ payload:
           table_group: histograms
           type: histogram
           details:
-            keyed: false 
+            keyed: false
             record_in_processes:
               contains: content
       keyedHistograms:


### PR DESCRIPTION
`payload.processes.gpu.histograms` should collect unkeyed histograms.