### PR TITLE
Revert "Bug 1597782 -Collect GPU process histograms correctly"

### DIFF
--- a/mozilla_schema_generator/configs/main.yaml
+++ b/mozilla_schema_generator/configs/main.yaml
@@ -75,7 +75,7 @@ payload:
           table_group: histograms
           type: histogram
           details:
-            keyed: false
+            keyed: true
             record_in_processes:
               contains: gpu
       keyedHistograms:

--- a/mozilla_schema_generator/configs/main.yaml
+++ b/mozilla_schema_generator/configs/main.yaml
@@ -41,7 +41,7 @@ payload:
           table_group: histograms
           type: histogram
           details:
-            keyed: false
+            keyed: false 
             record_in_processes:
               contains: content
       keyedHistograms:


### PR DESCRIPTION
Reverts mozilla/mozilla-schema-generator#103

This removed columns in the generated schemas in the following commit: https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/1f1ae08c08c3eb1bbdfcf813fb180e1422c94720

This is currently stalling schema deploys, so this will be backed out. We should ensure a review of the generated diff against the generated branch before merging to avoid this problem next time. 

cc @tdsmith 