### PR TITLE
Fix schema generation of main probes

### DIFF
--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -87,7 +87,7 @@ class GenericPing(object):
             except KeyError:
                 addtlProps = None
 
-            probe_schema = Schema(probe.get_schema(addtlProps))
+            probe_schema = Schema(probe.get_schema(addtlProps)).clone()
 
             if split and final_schema.get_size() + probe_schema.get_size() > max_size:
                 schemas.append(final_schema)


### PR DESCRIPTION
This fixes https://github.com/mozilla/mozilla-schema-generator/issues/115

Comparing the generated test-schema and the previously generated schema:

```diff
                       {
-                        "description": "Time from submission to dispatch of HTTP/3 transaction (ms)",
+                        "description": "Measures the number of milliseconds we spend synchronously notifying observers, keyed by topic. Note: only NotifyObservers calls which take over 500 microseconds are included in this probe.",
                         "mode": "NULLABLE",
                         "name": "value",
                         "type": "STRING"
@@ -53433,7 +53433,7 @@
                         "type": "STRING"
                       },
                       {
-                        "description": "Time from submission to dispatch of HTTP/3 transaction (ms)",
+                        "description": "OpenGL compositor runtime and dynamic failure IDs. This will record a count for each context creation success or failure. Each failure id is a unique identifier that can be traced back to a particular failure branch or blocklist rule.",
                         "mode": "NULLABLE",
                         "name": "value",
                         "type": "STRING"
@@ -53451,7 +53451,7 @@
                         "type": "STRING"
                       },
                       {
-                        "description": "Time from submission to dispatch of HTTP/3 transaction (ms)",
+                        "description": "Generic histogram to track uptake of remote content like blocklists, settings or updates.",
                         "mode": "NULLABLE",
                         "name": "value",
                         "type": "STRING"
@@ -53974,7 +53974,7 @@
                         "type": "STRING"
                       },
                       {
-                        "description": "Records bytes that have been transferred for search requests, including top-level documents, sub-resources, iframes and search suggestions. The key format could be one of:\n  <search-provider-name>\n  <search-provider-name>-pb\n  sggt-<search-engine-id>\n  sggt-<search-engine-id>-pb\n",
+                        "description": "Records KBs has been transferred for search requests, including top-level documents, sub-resources, iframes and search suggestions. The key format could be one of:\n  <search-provider-name>\n  <search-provider-name>-pb\n  sggt-<search-engine-id>\n  sggt-<search-engine-id>-pb\n",
                         "mode": "NULLABLE",
                         "name": "value",
                         "type": "INT64"
@@ -56486,7 +56486,7 @@
                         "type": "STRING"
                       },
                       {
-                        "description": "Time from submission to dispatch of HTTP/3 transaction (ms)",
+                        "description": "Generic histogram to track uptake of remote content like blocklists, settings or updates.",
                         "mode": "NULLABLE",
                         "name": "value",
                         "type": "STRING"
@@ -56511,7 +56511,7 @@
                         "type": "STRING"
                       },
                       {
-                        "description": "Time from submission to dispatch of HTTP/3 transaction (ms)",
+                        "description": "Generic histogram to track uptake of remote content like blocklists, settings or updates.",
                         "mode": "NULLABLE",
                         "name": "value",
                         "type": "STRING"
```