### PR TITLE
Fix #118 - Maintain schema compatibility for changed probe type

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -103,7 +103,9 @@ class GleanPing(GenericPing):
                 # Modify the definition with the truncated history.
                 hist_defn = defn.copy()
                 hist_defn[probe.history_key] = probe.definition_history[changepoint_index:]
-                incompatible_probe_type = GleanProbe(_id, hist_defn, pings=pings)
+                hist_defn["type"] = hist_defn[probe.history_key][0]["type"]
+                logging.info(hist_defn)
+                incompatible_probe_type = GleanProbe(_id, hist_defn, pings=ping)
                 processed.append(incompatible_probe_type)
 
         return processed

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -104,7 +104,7 @@ class GleanPing(GenericPing):
                 hist_defn = defn.copy()
                 hist_defn[probe.history_key] = probe.definition_history[changepoint_index:]
                 hist_defn["type"] = hist_defn[probe.history_key][0]["type"]
-                incompatible_probe_type = GleanProbe(_id, hist_defn, pings=ping)
+                incompatible_probe_type = GleanProbe(_id, hist_defn, pings=pings)
                 processed.append(incompatible_probe_type)
 
         return processed

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -82,7 +82,31 @@ class GleanPing(GenericPing):
             probes += list(dependency_probes.items())
 
         pings = self.get_pings()
-        return [GleanProbe(_id, defn, pings=pings) for _id, defn in probes]
+
+        processed = []
+        for _id, defn in probes:
+            probe = GleanProbe(_id, defn, pings=pings)
+            processed.append(probe)
+
+            # Manual handling of incompatible schema changes
+            if self.repo.startswith("fenix") and probe.get_name() == "installation.timestamp":
+                logging.info(f"Writing column {probe.get_name()} for compatibility.")
+                # See: https://github.com/mozilla/mozilla-schema-generator/issues/118
+                # Search through history for the "string" type and add a copy of
+                # the probe at that time in history. The changepoint signifies
+                # this event.
+                changepoint_index = 0
+                for definition in probe.definition_history:
+                    if definition["type"] != probe.get_type():
+                        break
+                    changepoint_index += 1
+                # Modify the definition with the truncated history.
+                hist_defn = defn.copy()
+                hist_defn[probe.history_key] = probe.definition_history[changepoint_index:]
+                incompatible_probe_type = GleanProbe(_id, hist_defn, pings=pings)
+                processed.append(incompatible_probe_type)
+
+        return processed
 
     def get_pings(self) -> Set[str]:
         url = self.ping_url_template.format(self.repo)

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -89,7 +89,14 @@ class GleanPing(GenericPing):
             processed.append(probe)
 
             # Manual handling of incompatible schema changes
-            if self.repo.startswith("fenix") and probe.get_name() == "installation.timestamp":
+            issue_118_affected = {
+                "fenix",
+                "fenix-nightly",
+                "firefox-android-nightly",
+                "firefox-android-beta",
+                "firefox-android-release",
+            }
+            if self.repo in issue_118_affected and probe.get_name() == "installation.timestamp":
                 logging.info(f"Writing column {probe.get_name()} for compatibility.")
                 # See: https://github.com/mozilla/mozilla-schema-generator/issues/118
                 # Search through history for the "string" type and add a copy of

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -104,7 +104,6 @@ class GleanPing(GenericPing):
                 hist_defn = defn.copy()
                 hist_defn[probe.history_key] = probe.definition_history[changepoint_index:]
                 hist_defn["type"] = hist_defn[probe.history_key][0]["type"]
-                logging.info(hist_defn)
                 incompatible_probe_type = GleanProbe(_id, hist_defn, pings=ping)
                 processed.append(incompatible_probe_type)
 

--- a/mozilla_schema_generator/probes.py
+++ b/mozilla_schema_generator/probes.py
@@ -166,12 +166,16 @@ class GleanProbe(Probe):
 
     def _set_definition(self, full_defn: dict):
         # Expose the entire history, for special casing of the probe.
-        self.definition_history = list(sorted(
-            full_defn[self.history_key], key=lambda x: datetime.fromisoformat(x["dates"]["last"])
-        ))
+        self.definition_history = list(
+            sorted(
+                full_defn[self.history_key],
+                key=lambda x: datetime.fromisoformat(x["dates"]["last"]),
+                reverse=True
+            )
+        )
 
         # The canonical definition for up-to-date schemas
-        self.definition = max(self.definition_history)
+        self.definition = self.definition_history[0]
 
     def _set_dates(self, definition: dict):
         vals = [datetime.fromisoformat(d["dates"]["first"]) for d in definition[self.history_key]]

--- a/mozilla_schema_generator/probes.py
+++ b/mozilla_schema_generator/probes.py
@@ -165,9 +165,13 @@ class GleanProbe(Probe):
             self.definition["send_in_pings"] = set(pings)
 
     def _set_definition(self, full_defn: dict):
-        self.definition = max(
+        # Expose the entire history, for special casing of the probe.
+        self.definition_history = list(sorted(
             full_defn[self.history_key], key=lambda x: datetime.fromisoformat(x["dates"]["last"])
-        )
+        ))
+
+        # The canonical definition for up-to-date schemas
+        self.definition = max(self.definition_history)
 
     def _set_dates(self, definition: dict):
         vals = [datetime.fromisoformat(d["dates"]["first"]) for d in definition[self.history_key]]


### PR DESCRIPTION
Fixes #118. This is done on a case-by-case basis. In particular, this adds a copy of the `installation.timestamp` metric as a string and a datetime.

```bash
export MPS_SSH_KEY_BASE64=$(cat ~/.ssh/id_rsa | base64)

git checkout master
make build && make run

git checkout type_change
make build && make run
```

This diff shows the change from master: https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/9c966c1c5e4b4982c6a1e5027df9a629bfbbf49b