### PR TITLE
[Bug 1614416] Add environment.system.os.hasSuperfetch and environment.system.os.hasPrefetch as common ping columns

### DIFF
--- a/mozilla_schema_generator/common_ping.py
+++ b/mozilla_schema_generator/common_ping.py
@@ -50,6 +50,10 @@ class CommonPing(GenericPing):
         schema.set_schema_elem(
                 prepend_properties(("environment", "system", "os", "version")), string)
         schema.set_schema_elem(
+                prepend_properties(("environment", "system", "os", "hasSuperfetch")), string)
+        schema.set_schema_elem(
+                prepend_properties(("environment", "system", "os", "hasPrefetch")), string)
+        schema.set_schema_elem(
                 prepend_properties(("environment", "addons", "theme", "foreignInstall")), integer)
         schema.set_schema_elem(active_addons + ("foreignInstall",), integer)
         schema.set_schema_elem(active_addons + ("version",), string)


### PR DESCRIPTION
This adds `environment.system.os.hasSuperfetch` and `environment.system.os.hasPrefetch` as common ping columns. 

Closes https://bugzilla.mozilla.org/show_bug.cgi?id=1614416 