### PR TITLE
[Bug 1626706] Fix deletion_request impression ID config

### DIFF
--- a/mozilla_schema_generator/configs/deletion_request.yaml
+++ b/mozilla_schema_generator/configs/deletion_request.yaml
@@ -10,3 +10,15 @@ payload:
             contains: main
           record_into_store:
             contains: deletion-request
+  processes:  # fields under processes are deprecated
+    parent:
+      scalars:
+        match:
+          table_group: scalars
+          type: scalar
+          details:
+            keyed: false
+            record_in_processes:
+              contains: main
+            record_into_store:
+              contains: deletion-request

--- a/mozilla_schema_generator/configs/deletion_request.yaml
+++ b/mozilla_schema_generator/configs/deletion_request.yaml
@@ -1,13 +1,12 @@
 payload:
-  processes:
+  scalars:
     parent:
-      scalars:
-        match:
-          table_group: scalars
-          type: scalar
-          details:
-            keyed: false
-            record_in_processes:
-              contains: main
-            record_into_store:
-              contains: deletion-request
+      match:
+        table_group: scalars
+        type: scalar
+        details:
+          keyed: false
+          record_in_processes:
+            contains: main
+          record_into_store:
+            contains: deletion-request


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1626706

For the deletion_request payload:
`{"payload":{"scalars":{"parent":{"deletion.request.impression_id":"{0d...a9}"}}}}`
the configuration needed to be changed. 

The resulting schema for deletion_request_v4:

```
[...]
{
    "mode": "REQUIRED",
    "name": "id",
    "type": "STRING"
  },
  {
    "fields": [
      {
        "fields": [
          {
            "fields": [
              {
                "mode": "REQUIRED",
                "name": "key",
                "type": "STRING"
              },
              {
                "mode": "REQUIRED",
                "name": "value",
                "type": "STRING"
              }
            ],
            "mode": "REPEATED",
            "name": "content",
            "type": "RECORD"
          },
          {
            "fields": [
              {
                "description": "An identifier used by user interaction pings in Pocket/newtab and Messaging System.\n",
                "mode": "NULLABLE",
                "name": "deletion_request_impression_id",
                "type": "STRING"
              }
            ],
            "mode": "NULLABLE",
            "name": "parent",
            "type": "RECORD"
          }
        ],
        "mode": "NULLABLE",
        "name": "scalars",
        "type": "RECORD"
      }
    ],
    "mode": "NULLABLE",
    "name": "payload",
    "type": "RECORD"
  },
  {
    "mode": "REQUIRED",
    "name": "type",
    "type": "STRING"
  },
[...]
```