### PR TITLE
Bug 1611027 - Update activeGMPlugins to be schema compatible via casting

### DIFF
--- a/mozilla_schema_generator/common_ping.py
+++ b/mozilla_schema_generator/common_ping.py
@@ -64,13 +64,8 @@ class CommonPing(GenericPing):
         schema.set_schema_elem(active_addons + ("version",), string)
         schema.set_schema_elem(active_addons + ("userDisabled",), integer)
         schema.set_schema_elem(
-            active_addons
-            + (
-                "activeGMPlugins",
-                "additionalProperties",
-                "properties",
-                "applyBackgroundUpdates",
-            ),
+            prepend_properties(("environment", "addons", "activeGMPlugins"))
+            + ("additionalProperties", "properties", "applyBackgroundUpdates"),
             with_description(
                 boolean,
                 "Cast into a boolean via mozilla-schema-generator. See bug 1611027.",

--- a/mozilla_schema_generator/common_ping.py
+++ b/mozilla_schema_generator/common_ping.py
@@ -43,6 +43,10 @@ class CommonPing(GenericPing):
         }
         boolean = {"type": "boolean"}
 
+        def with_description(dtype: dict, comment: str) -> dict:
+            """Add a description to the types defined above."""
+            return {**dtype, **dict(description=comment)}
+
         active_addons = prepend_properties(("environment", "addons", "activeAddons")) \
             + ("additionalProperties", "properties")
 
@@ -59,6 +63,19 @@ class CommonPing(GenericPing):
         schema.set_schema_elem(active_addons + ("foreignInstall",), integer)
         schema.set_schema_elem(active_addons + ("version",), string)
         schema.set_schema_elem(active_addons + ("userDisabled",), integer)
+        schema.set_schema_elem(
+            active_addons
+            + (
+                "activeGMPlugins",
+                "additionalProperties",
+                "properties",
+                "applyBackgroundUpdates",
+            ),
+            with_description(
+                boolean,
+                "Cast into a boolean via mozilla-schema-generator. See bug 1611027.",
+            ),
+        )
 
         return schema
 

--- a/mozilla_schema_generator/common_ping.py
+++ b/mozilla_schema_generator/common_ping.py
@@ -67,8 +67,8 @@ class CommonPing(GenericPing):
             prepend_properties(("environment", "addons", "activeGMPlugins"))
             + ("additionalProperties", "properties", "applyBackgroundUpdates"),
             with_description(
-                boolean,
-                "Cast into a boolean via mozilla-schema-generator. See bug 1611027.",
+                integer,
+                "Cast into an integer via mozilla-schema-generator. See bug 1611027.",
             ),
         )
 


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1611027)

This casts the integer into a boolean, since this is being reported differently in a few pings. https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/489

Diff can be found here: https://github.com/mozilla-services/mozilla-pipeline-schemas/compare/bdfb8fc~2...bdfb8fc

It looks like this is correctly nested.

```
wget https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/bdfb8fcab009521b93e386e15c9513519e1852b9/schemas/telemetry/crash/crash.4.bq
cat crash.4.bq | jq -r '.[] | recurse(.fields[]? + {parent: ((.parent? // []) + [.name])}) | .parent + [.name] | join(".")'  | grep active_gm_plugins

environment.addons.active_gm_plugins
environment.addons.active_gm_plugins.key
environment.addons.active_gm_plugins.value
environment.addons.active_gm_plugins.value.apply_background_updates
environment.addons.active_gm_plugins.value.user_disabled
environment.addons.active_gm_plugins.value.version
```