### PR TITLE
Fix #128 - Parallelize glean ping generation

### DIFF
--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -9,6 +9,7 @@ import sys
 import yaml
 import json
 import re
+import multiprocessing
 from pathlib import Path
 
 from .common_ping import CommonPing
@@ -209,8 +210,11 @@ def generate_glean_pings(config, out_dir, split, pretty, repo, generic_schema):
 
     config = Config("glean", config_data)
 
+    args = []
     for repo_name, repo_id in repos:
-        write_schema(repo_name, repo_id, config, out_dir, split, pretty, generic_schema)
+        args.append((repo_name, repo_id, config, out_dir, split, pretty, generic_schema))
+    with multiprocessing.Pool() as pool:
+        pool.starmap(write_schema, args)
 
 
 def write_schema(repo, repo_id, config, out_dir, split, pretty, generic_schema):


### PR DESCRIPTION
This fixes #128 by using multiprocessing to parallelize glean generation. Generating the glean ping is by far the slowest thing in the process. By default, this will use processes equal to the number of CPUs available. 

Before: `make run  0.45s user 0.20s system 0% cpu 8:23.99 total`
After: `make run  0.40s user 0.15s system 0% cpu 3:27.38 total`

One downside of this is that the logging is interleaved.