### PR TITLE
Cache JSON files locally

### DIFF
--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -43,7 +43,6 @@ class GenericPing(object):
         schema = self.get_schema()
         env = self.get_env()
 
-
         probes = self.get_probes()
 
         if split is None:


### PR DESCRIPTION
I looked things over and realized caching will be a real improvement.

`master`:
```
>> time python -m mozilla_schema_generator generate-glean-pings --out-dir glean/
real	8m0.271s
user	0m25.931s
sys	0m1.564s
```

`caching`, stale cache:
```
>> time python -m mozilla_schema_generator generate-glean-pings --out-dir glean/
real	0m17.616s
user	0m2.521s
sys	0m0.177s
```

Re-runs are free:
```
real	0m1.582s
user	0m1.477s
sys	0m0.100s
```