### PR TITLE
[Bug 1642389] Add payload.processes.parent.scalars column to new_profile

### DIFF
--- a/common_pings.json
+++ b/common_pings.json
@@ -37,6 +37,7 @@
         "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/new-profile/new-profile.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/new-profile/new-profile.4.schema.json",
+        "config": "new_profile.yaml"
     }
 ]

--- a/mozilla_schema_generator/configs/new_profile.yaml
+++ b/mozilla_schema_generator/configs/new_profile.yaml
@@ -1,0 +1,13 @@
+payload:
+  processes:
+    parent:
+      scalars:
+        match:
+          table_group: scalars
+          type: scalar
+          details:
+            keyed: false
+            record_in_processes:
+              contains: main
+            record_into_store:
+              contains: new-profile


### PR DESCRIPTION
The column `payload.processes.parent.scalars` is missing in `new_profile` and data is written to `additional_properties` as:

```
{"payload":{"processes":{"parent":{"scalars":{"startup.profile_selection_reason":"firstrun-created-default"}}}}}
```

With this change, the generated BQ `new_profile.4.bq` schema also includes the following fields:

```
...
  {
    "fields": [
      {
        "fields": [
          {
            "fields": [
              {
                "fields": [
                  {
                    "description": "How the profile was selected during startup. One of the following reasons:\n  unknown:\n    Generally should not happen, set as a default in case no other reason\n    occured.\n  profile-manager:\n    The profile was selected by the profile manager.\n  profile-reset:\n    The profile was selected for reset, normally this would mean a restart.\n  restart:\n    The user restarted the application, the same profile as previous will\n    be used.\n  argument-profile:\n    The profile was selected by the --profile command line argument.\n  argument-p:\n    The profile was selected by the -p command line argument.\n  firstrun-claimed-default:\n    A first run of a dedicated profiles build chose the old default\n    profile to be the default for this install.\n  firstrun-skipped-default:\n    A first run of a dedicated profiles build skipped over the old default\n    profile and created a new profile.\n  restart-claimed-default:\n    A first run of a dedicated profiles build after a restart chose the\n    old defaul…",
                    "mode": "NULLABLE",
                    "name": "startup_profile_selection_reason",
                    "type": "STRING"
                  }
                ],
                "mode": "NULLABLE",
                "name": "scalars",
                "type": "RECORD"
              }
            ],
            "mode": "NULLABLE",
            "name": "parent",
            "type": "RECORD"
          }
        ],
        "mode": "NULLABLE",
        "name": "processes",
        "type": "RECORD"
      },
      {
        "mode": "NULLABLE",
        "name": "reason",
        "type": "STRING"
      }
    ],
    "mode": "NULLABLE",
    "name": "payload",
    "type": "RECORD"
  },
...
```