### PR TITLE
[Bug 1645897] Add descriptions to generated Glean schemas

### DIFF
--- a/mozilla_schema_generator/probes.py
+++ b/mozilla_schema_generator/probes.py
@@ -220,4 +220,8 @@ class GleanProbe(Probe):
     def get_schema(self, addtlProps: Any) -> Any:
         if addtlProps is None:
             raise SchemaException("Additional Properties cannot be missing for Glean probes")
+
+        if self.description is not None:
+            addtlProps["description"] = self.description
+
         return addtlProps

--- a/mozilla_schema_generator/probes.py
+++ b/mozilla_schema_generator/probes.py
@@ -221,7 +221,7 @@ class GleanProbe(Probe):
         if addtlProps is None:
             raise SchemaException("Additional Properties cannot be missing for Glean probes")
 
-        if self.description is not None:
+        if self.description:
             addtlProps["description"] = self.description
 
         return addtlProps


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1645897

Descriptions now appear in generated schemas, see https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/57d236d038727fe573ccb3c8d5a945c8598df65b/schemas/org-mozilla-mozregression/usage/usage.1.bq#L340