### PR TITLE
[Bug 1660040] Handle sync ping histograms

### DIFF
--- a/common_pings.json
+++ b/common_pings.json
@@ -39,5 +39,9 @@
     {
         "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/new-profile/new-profile.4.schema.json",
         "config": "new_profile.yaml"
+    },
+    {
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/sync/sync.4.schema.json",
+        "config": "sync.yaml"
     }
 ]

--- a/mozilla_schema_generator/configs/sync.yaml
+++ b/mozilla_schema_generator/configs/sync.yaml
@@ -1,0 +1,20 @@
+payload:
+  histograms:
+    match:
+      table_group: histograms
+      type: histogram
+      name: 
+        any:
+          - PWMGR_BLOCKLIST_NUM_SITES
+          - PWMGR_FORM_AUTOFILL_RESULT
+          - PWMGR_LOGIN_LAST_USED_DAYS
+          - PWMGR_LOGIN_PAGE_SAFETY
+          - PWMGR_NUM_PASSWORDS_PER_HOSTNAME
+          - PWMGR_NUM_SAVED_PASSWORDS
+          - PWMGR_PROMPT_REMEMBER_ACTION
+          - PWMGR_PROMPT_UPDATE_ACTION
+          - PWMGR_SAVING_ENABLED
+      details:
+        keyed: false
+        record_in_processes:
+          contains: main

--- a/mozilla_schema_generator/matcher.py
+++ b/mozilla_schema_generator/matcher.py
@@ -14,8 +14,9 @@ class Matcher(object):
     type_key = "type"
     contains_key = "contains"
     not_key = "not"
+    any_key = "any"
 
-    keywords = {contains_key, not_key, type_key, table_group_key}
+    keywords = {contains_key, not_key, type_key, table_group_key, any_key}
 
     def __init__(self, match_obj: dict, *, _type=None, table_group=None):
         """
@@ -90,4 +91,7 @@ class Matcher(object):
                 if match_v[Matcher.not_key] == probe_v:
                     return False
 
+            # Match if any of the listed values match
+            if Matcher.any_key in match_v:
+                return probe_v in match_v[Matcher.any_key]
         return True

--- a/mozilla_schema_generator/probes.py
+++ b/mozilla_schema_generator/probes.py
@@ -95,6 +95,7 @@ class MainProbe(Probe):
     def _set_definition(self, full_defn: dict):
         history = [d for arr in full_defn[self.history_key].values() for d in arr]
         self.definition = max(history, key=lambda x: int(x["versions"]["first"]))
+        self.definition['name'] = full_defn[self.name_key]
         self._set_processes(history)
 
     def _set_processes(self, history):
@@ -195,6 +196,7 @@ class GleanProbe(Probe):
 
         # The canonical definition for up-to-date schemas
         self.definition = self.definition_history[0]
+        self.definition['name'] = full_defn[self.name_key]
 
     def _set_dates(self, definition: dict):
         vals = [

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -174,3 +174,51 @@ class TestMatcher(object):
         probe_defn['history'][0]['send_in_pings'] = ['baseline']
         probe = GleanProbe('histogram/name', probe_defn)
         assert not matcher.matches(probe)
+
+    def test_any_match(self):
+        match_obj = {
+            'table_group': 'histograms',
+            'type': 'histogram',
+            'name': {
+                'any': ['foo', 'bar']
+            }
+        }
+
+        probe_defn = {
+            'name': 'not-matching-name',
+            'type': 'histogram',
+            'first_added': {'nightly': '2019-02-02 02:02:00'},
+            'history': {
+                'nightly': [{
+                    'bug_numbers': [1351383],
+                    'cpp_guard': None,
+                    'description': 'Whether we have layed out any display:block containers with '
+                                   'not-yet-supported properties from CSS Box Align.',
+                    'details': {'high': 2,
+                                'keyed': False,
+                                'kind': 'boolean',
+                                'low': 1,
+                                'n_buckets': 3,
+                                'record_in_processes': ['main', 'content']},
+                    'expiry_version': '57',
+                    'notification_emails': ['bwerth@mozilla.com'],
+                    'optout': True,
+                    'revisions': {'first': 'f9605772a0c9098ed1bcaa98089b2c944ed69e9b',
+                                  'last': '8e818b5e9b6bef0fc1a5c527ecf30b0d56a02f14'},
+                    'versions': {'first': '55', 'last': '57'}
+                }]
+            }
+        }
+
+        matcher = Matcher(match_obj)
+        probe = MainProbe('histogram/name', probe_defn)
+
+        assert not matcher.matches(probe)
+
+        probe_defn['name'] = 'foo'
+        probe = MainProbe('histogram/name', probe_defn)
+        assert matcher.matches(probe)
+
+        probe_defn['name'] = 'bar'
+        probe = MainProbe('histogram/name', probe_defn)
+        assert matcher.matches(probe)


### PR DESCRIPTION
Sync pings have a defined set of histograms: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/sync-ping.html#histograms-in-the-sync-ping

Currently, those are written to `additional_properties` and appear in the missing columns dashboard as `payload.histograms`. 

The diff between the old and the generated sync.4.bq schema:

```diff

@@ -355,6 +355,67 @@
         "name": "events",
         "type": "RECORD"
       },
+      {
+        "fields": [
+          {
+            "description": "The number of sites for which the user has explicitly rejected saving logins",
+            "mode": "NULLABLE",
+            "name": "pwmgr_blocklist_num_sites",
+            "type": "STRING"
+          },
+          {
+            "description": "The result of auto-filling a login form. See http://mzl.la/1Mbs6jL for bucket descriptions.",
+            "mode": "NULLABLE",
+            "name": "pwmgr_form_autofill_result",
+            "type": "STRING"
+          },
+          {
+            "description": "Time in days each saved login was last used",
+            "mode": "NULLABLE",
+            "name": "pwmgr_login_last_used_days",
+            "type": "STRING"
+          },
+          {
+            "description": "The safety of a page where we see a password field. (0: safe page & safe submit; 1: safe page & unsafe submit; 2: safe page & unknown submit; 3: unsafe page & safe submit; 4: unsafe page & unsafe submit; 5: unsafe page & unknown submit)",
+            "mode": "NULLABLE",
+            "name": "pwmgr_login_page_safety",
+            "type": "STRING"
+          },
+          {
+            "description": "The number of passwords per hostname",
+            "mode": "NULLABLE",
+            "name": "pwmgr_num_passwords_per_hostname",
+            "type": "STRING"
+          },
+          {
+            "description": "Total number of saved logins, including those that cannot be decrypted",
+            "mode": "NULLABLE",
+            "name": "pwmgr_num_saved_passwords",
+            "type": "STRING"
+          },
+          {
+            "description": "Action taken by user through prompt for creating a login. (0=Prompt displayed [always recorded], 1=Add login, 2=Don't save now, 3=Never save)",
+            "mode": "NULLABLE",
+            "name": "pwmgr_prompt_remember_action",
+            "type": "STRING"
+          },
+          {
+            "description": "Action taken by user through prompt for modifying a login. (0=Prompt displayed [always recorded], 1=Update login, 2=Don't update, 3=Remove saved login)",
+            "mode": "NULLABLE",
+            "name": "pwmgr_prompt_update_action",
+            "type": "STRING"
+          },
+          {
+            "description": "Number of users who have password saving on globally",
+            "mode": "NULLABLE",
+            "name": "pwmgr_saving_enabled",
+            "type": "STRING"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "histograms",
+        "type": "RECORD"
+      },
       {
         "fields": [
           {
```