### PR TITLE
Exclude metadata/metaschema

### DIFF
--- a/disallowlist
+++ b/disallowlist
@@ -3,6 +3,7 @@ metadata/structured-ingestion/.*
 metadata/telemetry-ingestion/.*
 metadata/credentials/.*
 metadata/sources/.*
+metadata/metaschema/.*
 glean/.*
 telemetry/first-shutdown/.*
 telemetry/disableSHA1rollout/.*


### PR DESCRIPTION
This new metadata schema is introduced in
https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/579
and should not have a BQ schema generated.