### PR TITLE
Accumulate http response as bytestring

### DIFF
--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -176,12 +176,16 @@ class GenericPing(object):
         r = requests.get(url, stream=True)
         r.raise_for_status()
 
-        final_json = ""
+        json_bytes = b""
 
-        for chunk in r.iter_content(chunk_size=1024):
-            if chunk:
-                final_json += chunk.decode(r.encoding or GenericPing.default_encoding)
+        try:
+            for chunk in r.iter_content(chunk_size=1024):
+                if chunk:
+                    json_bytes += chunk
+        except ValueError as e:
+            raise ValueError("Could not parse " + url) from e
 
+        final_json = json_bytes.decode(r.encoding or GenericPing.default_encoding)
         GenericPing._add_to_cache(no_param_url, final_json)
 
         return final_json


### PR DESCRIPTION
After https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/579
was merged, schema generation was raising an error when processing the
heartbeat schema.

I believe what happened is that one of our 1024 byte chunks happened to land
within a multibyte character. We were decoding each chunk to text, which wasn't
tolerant to the possibility of a chunk ending within a multibyte character.

With this change, I was able to successfully run on the current mps content.