### PR TITLE
Inject mozPipelineMetadata to generated Glean json schemas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN pip install -r requirements/test_requirements.txt
 ADD . ${HOME}/mozilla-schema-generator
 ENV PATH $PATH:${HOME}/mozilla-schema-generator/bin
 
-RUN pip install -e ${HOME}/mozilla-schema-generator
+RUN pip install --no-dependencies -e ${HOME}/mozilla-schema-generator
 
 # Drop root and change ownership of the application folder to the user
 RUN chown -R ${USER_ID}:${GROUP_ID} ${HOME}

--- a/bin/alias_schemas
+++ b/bin/alias_schemas
@@ -57,7 +57,7 @@ def main(aliases_path, base_dir):
                 fname = source.name.replace(source_doctype, dest_doctype)
                 dest = dest_dir / fname
 
-                print(f"Aliasing {dest} to {source}")
+                print(f"Aliasing {source} to {dest}")
 
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy(source, dest)

--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -214,16 +214,21 @@ def generate_glean_pings(config, out_dir, split, pretty, repo, generic_schema):
 
 
 def write_schema(repo, repo_id, config, out_dir, split, pretty, generic_schema):
-    schema_generator = GleanPing(repo)
+    schema_generator = GleanPing(repo, repo_id)
     schemas = schema_generator.generate_schema(config, split=False, generic_schema=generic_schema)
-    dump_schema(schemas, out_dir.joinpath(repo_id), pretty)
+    dump_schema(schemas, out_dir and out_dir.joinpath(repo_id), pretty)
 
 
 def dump_schema(schemas, out_dir, pretty, *, version=1):
-    json_dump_args = {'cls': SchemaEncoder}
+    json_dump_args = {
+        'cls': SchemaEncoder
+    }
     if pretty:
-        json_dump_args['indent'] = 4
-        json_dump_args['separators'] = (',', ':')
+        json_dump_args.update({
+            'indent': 4,
+            'separators': (',', ':'),
+            'sort_keys': True,
+        })
 
     if not out_dir:
         print(json.dumps(schemas, **json_dump_args))

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -62,13 +62,12 @@ class TestGleanPing(object):
 
     def test_generic_schema(self, glean, config):
         schemas = glean.generate_schema(config, split=False, generic_schema=True)
-        generic_schema = glean.get_schema().schema
         assert schemas.keys() == {"baseline", "events", "metrics", "deletion-request"}
 
         final_schemas = {k: schemas[k][0].schema for k in schemas}
         for name, schema in final_schemas.items():
-            meta = schema.pop("mozPipelineMetadata")
-            assert meta == {
+            generic_schema = glean.get_schema().schema
+            generic_schema["mozPipelineMetadata"] = {
                 'bq_dataset_family': 'org_mozilla_glean',
                 'bq_metadata_format': 'structured',
                 'bq_table': name.replace("-", "_") + '_v1',

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -17,7 +17,7 @@ from typing import Dict, List
 
 @pytest.fixture
 def glean():
-    return glean_ping.GleanPing("glean")
+    return glean_ping.GleanPing("glean", "org-mozilla-glean")
 
 
 @pytest.fixture
@@ -67,11 +67,17 @@ class TestGleanPing(object):
 
         final_schemas = {k: schemas[k][0].schema for k in schemas}
         for name, schema in final_schemas.items():
+            meta = schema.pop("mozPipelineMetadata")
+            assert meta == {
+                'bq_dataset_family': 'org_mozilla_glean',
+                'bq_metadata_format': 'structured',
+                'bq_table': name.replace("-", "_") + '_v1',
+            }
             print_and_test(generic_schema, schema)
 
     def test_missing_data(self, config):
         # When there are no files, this should error
 
-        not_glean = NoProbeGleanPing("LeanGleanPingNoIding")
+        not_glean = NoProbeGleanPing("LeanGleanPingNoIding", "org-mozilla-lean")
         with pytest.raises(requests.exceptions.HTTPError):
             not_glean.generate_schema(config, split=False)


### PR DESCRIPTION
Makes Glean JSON schemas parallel to hand-written JSON schemas. See
https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/579