### PR TITLE
Use bq_metadata_format for choosing metadata structure

### DIFF
--- a/bin/metadata_merge
+++ b/bin/metadata_merge
@@ -2,13 +2,14 @@
 
 import click
 import json
+from os import path
 
 @click.command()
 @click.argument(
-    'metadata',
+    'metadata_dir',
     type=click.Path(
-        dir_okay=False,
-        file_okay=True,
+        dir_okay=True,
+        file_okay=False,
         writable=False,
         exists=True,
     ),
@@ -24,14 +25,26 @@ import json
     ),
     required=True
 )
-def main(metadata, schema):
-    print("Merging metadata {} and schema {}".format(metadata, schema))
-
-    with open(metadata, "r") as f:
-        metadata_contents = json.load(f)
+def main(metadata_dir, schema):
+    print("Merging metadata into schema {}".format(schema))
 
     with open(schema, "r") as f:
         schema_contents = json.load(f)
+
+    meta = schema_contents.get("mozPipelineMetadata", {})
+    bq_metadata_format = meta.get("bq_metadata_format", None)
+    if bq_metadata_format:
+        print("Using format {} for metadata merged into schema {}".format(bq_metadata_format, schema))
+    else:
+        print("Skipping metadata merge for schema {}".format(schema))
+        return
+
+    metadata = path.join(
+        metadata_dir,
+        "{0}-ingestion/{0}-ingestion.1.schema.json".format(bq_metadata_format))
+
+    with open(metadata, "r") as f:
+        metadata_contents = json.load(f)
 
     properties = metadata_contents.get("properties", {})
     required = metadata_contents.get("required", [])

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -139,16 +139,24 @@ class GleanPing(GenericPing):
                 matcher.matcher["send_in_pings"]["contains"] = ping
             new_config = Config(ping, matchers=matchers)
 
-            if generic_schema:  # Use the generic glean ping schema
-                schema = self.get_schema()
-                schema.schema['mozPipelineMetadata'] = {
+            defaults = {
+                "mozPipelineMetadata": {
                     "bq_dataset_family": self.app_id.replace("-", "_"),
                     "bq_table": ping.replace("-", "_") + "_v1",
                     "bq_metadata_format": "structured",
                 }
+            }
+
+            if generic_schema:  # Use the generic glean ping schema
+                schema = self.get_schema()
+                schema.schema.update(defaults)
                 schemas[new_config.name] = [schema]
             else:
-                schemas.update(super().generate_schema(new_config))
+                generated = super().generate_schema(new_config)
+                for value in generated.values():
+                    for schema in value:
+                        schema.schema.update(defaults)
+                schemas.update(generated)
 
         return schemas
 


### PR DESCRIPTION
Depends on https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/598

This change should cause no difference to generated output, since the schemas now contain metadata to determine which format to use.