### PR TITLE
Respect configured MPS_BRANCH_SOURCE for all URLs

### DIFF
--- a/bin/schema_generator.sh
+++ b/bin/schema_generator.sh
@@ -124,7 +124,7 @@ function commit_schemas() {
     git checkout ./*.schema.json
 
     # Add Glean JSON schemas with generic schema
-    mozilla-schema-generator generate-glean-pings --out-dir $MPS_SCHEMAS_DIR --pretty --generic-schema
+    mozilla-schema-generator generate-glean-pings --out-dir $MPS_SCHEMAS_DIR --pretty --generic-schema --mps-branch $MPS_BRANCH_SOURCE
     find . -name "*.schema.json" -type f -exec git add {} +
 
     git commit -a -m "Interim Commit"
@@ -150,9 +150,9 @@ function main() {
     clone_and_configure_mps
 
     # Generate new schemas
-    mozilla-schema-generator generate-main-ping --out-dir ./telemetry
-    mozilla-schema-generator generate-common-pings --common-pings-config $COMMON_PINGS_PATH --out-dir ./telemetry
-    mozilla-schema-generator generate-glean-pings --out-dir .
+    mozilla-schema-generator generate-main-ping --out-dir ./telemetry --mps-branch $MPS_BRANCH_SOURCE
+    mozilla-schema-generator generate-common-pings --common-pings-config $COMMON_PINGS_PATH --mps-branch $MPS_BRANCH_SOURCE --out-dir ./telemetry
+    mozilla-schema-generator generate-glean-pings --mps-branch $MPS_BRANCH_SOURCE --out-dir .
 
     # Remove all non-json schemas (e.g. parquet)
     find . -not -name "*.schema.json" -type f -exec rm {} +

--- a/common_pings.json
+++ b/common_pings.json
@@ -1,51 +1,51 @@
 [
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/voice/voice.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/voice/voice.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/deletion-request/deletion-request.4.schema.json",
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/deletion-request/deletion-request.4.schema.json",
         "config": "deletion_request.yaml"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/heartbeat/heartbeat.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/heartbeat/heartbeat.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/crash/crash.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/crash/crash.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/modules/modules.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/modules/modules.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/testpilot/testpilot.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/testpilot/testpilot.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/update/update.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/update/update.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/event/event.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/event/event.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/saved-session/saved-session.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/saved-session/saved-session.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json"
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/new-profile/new-profile.4.schema.json",
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/new-profile/new-profile.4.schema.json",
         "config": "new_profile.yaml"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/sync/sync.4.schema.json",
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/sync/sync.4.schema.json",
         "config": "sync.yaml"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json",
+        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json",
         "config": "account_ecosystem.yaml"
     }
 ]

--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -57,8 +57,14 @@ SCHEMA_NAME_RE = re.compile(r".+/([a-zA-Z0-9_-]+)\.([0-9]+)\.schema\.json")
           "schemas that are outputted. Otherwise "
           "the schemas will be on one line."),
 )
-def generate_main_ping(config, out_dir, split, pretty):
-    schema_generator = MainPing()
+@click.option(
+    '--mps-branch',
+    help=("If specified, the source branch of "
+          "mozilla-pipeline-schemas to reference"),
+    required=False,
+)
+def generate_main_ping(config, out_dir, split, pretty, mps_branch):
+    schema_generator = MainPing(mps_branch=mps_branch)
     if out_dir:
         out_dir = Path(out_dir)
 
@@ -111,7 +117,13 @@ def generate_main_ping(config, out_dir, split, pretty):
     help=("File containing URLs to schemas and configs "
           "of pings in the common ping format."),
 )
-def generate_common_pings(config_dir, out_dir, split, pretty, common_pings_config):
+@click.option(
+    '--mps-branch',
+    help=("If specified, the source branch of "
+          "mozilla-pipeline-schemas to reference"),
+    required=False,
+)
+def generate_common_pings(config_dir, out_dir, split, pretty, common_pings_config, mps_branch):
     if split:
         raise NotImplementedError("Splitting of common pings is not yet supported.")
 
@@ -124,7 +136,7 @@ def generate_common_pings(config_dir, out_dir, split, pretty, common_pings_confi
         common_pings = json.load(f)
 
     for common_ping in common_pings:
-        schema_generator = CommonPing(common_ping["schema_url"])
+        schema_generator = CommonPing(common_ping["schema_url"], mps_branch=mps_branch)
 
         config_data = {}
 
@@ -192,7 +204,13 @@ def generate_common_pings(config_dir, out_dir, split, pretty, common_pings_confi
           "but instead the generic schema is used for "
           "every application's glean pings.")
 )
-def generate_glean_pings(config, out_dir, split, pretty, repo, generic_schema):
+@click.option(
+    '--mps-branch',
+    help=("If specified, the source branch of "
+          "mozilla-pipeline-schemas to reference"),
+    required=False,
+)
+def generate_glean_pings(config, out_dir, split, pretty, repo, generic_schema, mps_branch):
     if split:
         raise NotImplementedError("Splitting of Glean pings is not yet supported.")
 
@@ -210,11 +228,11 @@ def generate_glean_pings(config, out_dir, split, pretty, repo, generic_schema):
     config = Config("glean", config_data)
 
     for repo_name, repo_id in repos:
-        write_schema(repo_name, repo_id, config, out_dir, split, pretty, generic_schema)
+        write_schema(repo_name, repo_id, config, out_dir, split, pretty, generic_schema, mps_branch)
 
 
-def write_schema(repo, repo_id, config, out_dir, split, pretty, generic_schema):
-    schema_generator = GleanPing(repo, repo_id)
+def write_schema(repo, repo_id, config, out_dir, split, pretty, generic_schema, mps_branch):
+    schema_generator = GleanPing(repo, repo_id, mps_branch=mps_branch)
     schemas = schema_generator.generate_schema(config, split=False, generic_schema=generic_schema)
     dump_schema(schemas, out_dir and out_dir.joinpath(repo_id), pretty)
 

--- a/mozilla_schema_generator/common_ping.py
+++ b/mozilla_schema_generator/common_ping.py
@@ -22,8 +22,8 @@ class CommonPing(GenericPing):
     env_url = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/templates/include/telemetry/environment.1.schema.json" # noqa E501
     probes_url = GenericPing.probe_info_base_url + "/firefox/all/main/all_probes"
 
-    def __init__(self, schema_url):
-        super().__init__(schema_url, self.env_url, self.probes_url)
+    def __init__(self, schema_url, **kwargs):
+        super().__init__(schema_url, self.env_url, self.probes_url, **kwargs)
 
     def get_schema(self):
         schema = super().get_schema()

--- a/mozilla_schema_generator/common_ping.py
+++ b/mozilla_schema_generator/common_ping.py
@@ -19,7 +19,8 @@ class CommonPing(GenericPing):
     # ONLY DECREMENT, or the schema will change in an incompatible way!
     MIN_FX_VERSION = 30
 
-    env_url = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/templates/include/telemetry/environment.1.schema.json" # noqa E501
+    env_url = ("https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas"
+               "/{branch}/templates/include/telemetry/environment.1.schema.json")
     probes_url = GenericPing.probe_info_base_url + "/firefox/all/main/all_probes"
 
     def __init__(self, schema_url, **kwargs):

--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -24,13 +24,10 @@ class GenericPing(object):
     extra_schema_key = "extra"
     cache_dir = pathlib.Path(".probe_cache")
 
-    def __init__(self, schema_url, env_url, probes_url, mps_branch=None):
-        self.schema_url = schema_url
-        self.env_url = env_url
+    def __init__(self, schema_url, env_url, probes_url, mps_branch="master"):
+        self.schema_url = schema_url.format(branch=mps_branch)
+        self.env_url = env_url.format(branch=mps_branch)
         self.probes_url = probes_url
-        if mps_branch is not None:
-            self.schema_url = schema_url.replace("/master/", f"/{mps_branch}/")
-            self.env_url = env_url.replace("/master/", f"/{mps_branch}/")
 
     def get_schema(self) -> Schema:
         return Schema(self._get_json(self.schema_url))

--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -24,10 +24,13 @@ class GenericPing(object):
     extra_schema_key = "extra"
     cache_dir = pathlib.Path(".probe_cache")
 
-    def __init__(self, schema_url, env_url, probes_url):
+    def __init__(self, schema_url, env_url, probes_url, mps_branch=None):
         self.schema_url = schema_url
         self.env_url = env_url
         self.probes_url = probes_url
+        if mps_branch is not None:
+            self.schema_url = schema_url.replace("/master/", f"/{mps_branch}/")
+            self.env_url = env_url.replace("/master/", f"/{mps_branch}/")
 
     def get_schema(self) -> Schema:
         return Schema(self._get_json(self.schema_url))

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -29,13 +29,14 @@ class GleanPing(GenericPing):
     default_dependencies = ['glean']
     ignore_pings = {"all-pings", "all_pings", "default", "glean_ping_info", "glean_client_info"}
 
-    def __init__(self, repo, app_id):  # TODO: Make env-url optional
+    def __init__(self, repo, app_id, **kwargs):  # TODO: Make env-url optional
         self.repo = repo
         self.app_id = app_id
         super().__init__(
             self.schema_url,
             self.schema_url,
-            self.probes_url_template.format(repo)
+            self.probes_url_template.format(repo),
+            **kwargs
         )
 
     def get_dependencies(self):

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -20,7 +20,8 @@ logger = logging.getLogger(__name__)
 
 class GleanPing(GenericPing):
 
-    schema_url = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master/schemas/glean/glean/glean.1.schema.json" # noqa E501
+    schema_url = ("https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas"
+                  "/{branch}/schemas/glean/glean/glean.1.schema.json")
     probes_url_template = GenericPing.probe_info_base_url + "/glean/{}/metrics"
     ping_url_template = GenericPing.probe_info_base_url + "/glean/{}/pings"
     repos_url = GenericPing.probe_info_base_url + "/glean/repositories"

--- a/mozilla_schema_generator/main_ping.py
+++ b/mozilla_schema_generator/main_ping.py
@@ -14,8 +14,8 @@ class MainPing(CommonPing):
         "/schemas/telemetry/main/main.4.schema.json"
     )
 
-    def __init__(self):
-        super().__init__(self.schema_url)
+    def __init__(self, **kwargs):
+        super().__init__(self.schema_url, **kwargs)
 
     def _update_env(self, schema):
         integer = {"type": "integer"}

--- a/mozilla_schema_generator/main_ping.py
+++ b/mozilla_schema_generator/main_ping.py
@@ -10,8 +10,8 @@ from .utils import prepend_properties
 
 class MainPing(CommonPing):
     schema_url = (
-        "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master"
-        "/schemas/telemetry/main/main.4.schema.json"
+        "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas"
+        "/{branch}/schemas/telemetry/main/main.4.schema.json"
     )
 
     def __init__(self, **kwargs):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,8 +13,8 @@ from mozilla_schema_generator.utils import _get, prepend_properties
 @pytest.fixture
 def ping():
     schema_url = (
-        "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/master"
-        "/schemas/telemetry/event/event.4.schema.json"
+        "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas"
+        "/{branch}/schemas/telemetry/event/event.4.schema.json"
     )
     return common_ping.CommonPing(schema_url)
 


### PR DESCRIPTION
Current behavior is that MPS_BRANCH_SOURCE is ignored for Glean pings and common pings, which always reference master.

I've confirmed that running `make build && make run` with these changes produces no difference in output, thus the code doesn't push a new commit to test-generated-schemas.