### PR TITLE
[Bug 1660040] Add legacy PWMGR histograms to sync ping

### DIFF
--- a/mozilla_schema_generator/configs/sync.yaml
+++ b/mozilla_schema_generator/configs/sync.yaml
@@ -14,6 +14,13 @@ payload:
           - PWMGR_PROMPT_REMEMBER_ACTION
           - PWMGR_PROMPT_UPDATE_ACTION
           - PWMGR_SAVING_ENABLED
+          - PWMGR_MANAGE_VISIBILITY_TOGGLED
+          - PWMGR_MANAGE_COPIED_PASSWORD
+          - PWMGR_MANAGE_COPIED_USERNAME
+          - PWMGR_MANAGE_DELETED_ALL
+          - PWMGR_MANAGE_DELETED
+          - PWMGR_MANAGE_OPENED
+          - PWMGR_MANAGE_SORTED
       details:
         keyed: false
         record_in_processes:


### PR DESCRIPTION
There are some histograms sent by older FF versions (68) that still appear in sync pings. These have been removed, e.g. in https://hg.mozilla.org/mozilla-central/rev/263b8a0e6c34, but I guess we still want to add them so that they are not treated as `additional_properties` anymore.