### PR TITLE
Remove first-shutdown from disallowlist

### DIFF
--- a/disallowlist
+++ b/disallowlist
@@ -5,6 +5,5 @@ metadata/credentials/.*
 metadata/sources/.*
 metadata/metaschema/.*
 glean/.*
-telemetry/first-shutdown/.*
 telemetry/disableSHA1rollout/.*
 telemetry/untrustedModules/.*


### PR DESCRIPTION
This appears to be an artifact of m-s-g before the concept of aliases was introduced. See https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/383

We have added saved-session as a main ping alias as well, but don't include it in the disallowlist. These should be symmetrical.