### PR TITLE
Hard fail

### DIFF
--- a/mozilla_schema_generator/schema.py
+++ b/mozilla_schema_generator/schema.py
@@ -183,7 +183,7 @@ class Schema(object):
 
         def is_type(k, _):
             # Handles the field with name "type" by ignoring properties
-            return k[-1] == "type" and (len(k) < 2 or k[-2] != "properties")
+            return k[-1] == "type" and not is_property(key, elem)
 
         from_types = unnest_dict(_from, should_add=is_type)
         to_types = unnest_dict(_to, should_add=is_type)

--- a/mozilla_schema_generator/utils.py
+++ b/mozilla_schema_generator/utils.py
@@ -4,9 +4,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import queue
 
 from typing import Any, Tuple
-
 from itertools import chain
 
 
@@ -32,3 +32,29 @@ def prepend_properties(key: Tuple[str]) -> Tuple[str]:
     ```
     """
     return tuple(chain.from_iterable(zip(("properties" for k in key), key)))
+
+
+def unnest_dict(_dict, should_add=lambda _, e: not isinstance(e, dict), should_continue=lambda _, e: isinstance(e, dict)):
+    """
+    Transform the nested dict into a single level
+    e.g. {"a": {"b": True}} becomes {"a.b": True}
+    """
+    keys = queue.SimpleQueue()
+    unnested = {}
+
+    for key, v in _dict.items():
+        k = (key,)
+        if should_continue(k, v):
+            keys.put(k)
+
+    while not keys.empty():
+        key = keys.get()
+        elem = _get(_dict, key)
+
+        if should_add(key, elem):
+            unnested[key] = elem
+        if should_continue(key, elem):
+            for k, v in elem.items():
+                keys.put(key + (k,))
+
+    return unnested

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -100,3 +100,155 @@ class TestSchema(object):
                 propagate=True)
 
         print_and_test(schema.schema, res_schema.schema)
+
+    def test_valid_schema_change(self):
+        _from = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": "string"
+                }
+            }
+        }
+
+        _to = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": "string"
+                },
+                "second": {
+                    "type": "boolean"
+                }
+            }
+        }
+
+        assert len(Schema.is_valid_schema_change(_from, _to)) == 0
+
+    def test_valid_schema_change__nested(self):
+        _from = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": "object",
+                    "properties": {
+                        "a": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+
+        _to = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": "object",
+                    "properties": {
+                        "a": {
+                            "type": "string"
+                        },  
+                        "b": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        }
+
+        assert len(Schema.is_valid_schema_change(_from, _to)) == 0
+
+    def test_valid_schema_change__make_nullable(self):
+        _from = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": "string"
+                },
+                "second": {
+                    "type": "string"
+                }
+            },
+            "required": ["first"]
+        }
+
+        _to = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": "string"
+                },
+                "second": {
+                    "type": ["string", "null"]
+                }
+            }
+        }
+
+        assert len(Schema.is_valid_schema_change(_from, _to)) == 0
+
+    def test_invalid_schema_change__removing_column(self):
+        _from = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": "string"
+                },
+                "second": {
+                    "type": "boolean"
+                }
+            }
+        }
+
+        _to = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": "string"
+                }
+            }
+        }
+
+        assert len(Schema.is_valid_schema_change(_from, _to)) > 0
+
+    def test_invalid_schema_change__changing_type(self):
+        _from = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": "string"
+                }
+            }
+        }
+
+        _to = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": "boolean"
+                }
+            }
+        }
+
+        assert len(Schema.is_valid_schema_change(_from, _to)) == 1
+
+    def test_valid_schema_change__to_non_required(self):
+        _from = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": "string"
+                }
+            }
+        }
+
+        _to = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "first": {
+                    "type": ["string", "null"]
+                }
+            }
+        }
+
+        assert Schema.is_valid_schema_change(_from, _to) == {}


### PR DESCRIPTION
Fixes #74.

For the current `HEAD`, this actually results in:

```
Schema Incompatible Changes Found

telemetry/android-anr-report/android-anr-report.3.schema.json
File Removed (disallowed)

telemetry/android-anr-report/android-anr-report.8.schema.json
File Removed (disallowed)

telemetry/android-anr-report/android-anr-report.9.schema.json
File Removed (disallowed)

telemetry/android-anr-report/android-anr-report.4.schema.json
File Removed (disallowed)

telemetry/android-anr-report/android-anr-report.1.schema.json
File Removed (disallowed)

telemetry/android-anr-report/android-anr-report.7.schema.json
File Removed (disallowed)

telemetry/disableSHA1rollout/disableSHA1rollout.4.schema.json
File Removed (disallowed)

telemetry/android-anr-report/android-anr-report.5.schema.json
File Removed (disallowed)

telemetry/untrustedModules/untrustedModules.4.schema.json
File Removed (disallowed)

telemetry/android-anr-report/android-anr-report.6.schema.json
File Removed (disallowed)

telemetry/android-anr-report/android-anr-report.2.schema.json
File Removed (disallowed)

telemetry/android-anr-report/android-anr-report.10.schema.json
```

I added the commit allowlist to let us bypass checks for certain commits on `generated-schemas`.