### PR TITLE
Clarifying commentary, esp. around how aliases work

### DIFF
--- a/bin/alias_schemas
+++ b/bin/alias_schemas
@@ -53,7 +53,7 @@ def main(aliases_path, base_dir):
 
             assert source_dir.exists()
 
-            for source in source_dir.glob('*'):
+            for source in source_dir.glob('*.bq'):
                 fname = source.name.replace(source_doctype, dest_doctype)
                 dest = dest_dir / fname
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -61,7 +61,6 @@ class TestSchemaAliasing(object):
         assert res.returncode == 0
 
         test_path = pathlib.Path(self.base_dir) / self.source_namespace / test_doctype
-        assert (test_path / f"{test_doctype}.1.schema.json").exists()
         assert (test_path / f"{test_doctype}.1.bq").exists()
 
     def test_aliasing_new_namespace(self):
@@ -81,7 +80,6 @@ class TestSchemaAliasing(object):
         assert res.returncode == 0
 
         test_path = pathlib.Path(self.base_dir) / test_namespace / test_doctype
-        assert (test_path / f"{test_doctype}.1.schema.json").exists()
         assert (test_path / f"{test_doctype}.1.bq").exists()
 
     def test_no_aliasing(self):


### PR DESCRIPTION
I mistakenly filed https://github.com/mozilla/mozilla-schema-generator/pull/150 due to a misconception about how schema aliasing worked. Until this point, I hadn't fully understood that the modifications we make to JSON schemas are
mostly thrown out before committing changes.

This PR mostly just adds commentary, but does change internal behavior by copying around only BQ schemas when aliasing, making it more clear that aliasing has no effect on the JSON schemas committed to the published branch.

Before this change, the logs show:

```
Aliasing telemetry/main/main.4.bq to telemetry/saved-session/saved-session.4.bq
Aliasing telemetry/main/main.4.schema.json to telemetry/saved-session/saved-session.4.schema.json
Aliasing telemetry/main/main.4.bq to telemetry/first-shutdown/first-shutdown.4.bq
Aliasing telemetry/main/main.4.schema.json to telemetry/first-shutdown/first-shutdown.4.schema.json
```

and I was misdirected by those messages into thinking that we would be overwriting the `schema.json` files in the published output with the contents of `main.4.schema.json`.

With this change, the logs show:

```
Aliasing telemetry/main/main.4.bq to telemetry/saved-session/saved-session.4.bq
Aliasing telemetry/main/main.4.bq to telemetry/first-shutdown/first-shutdown.4.bq
```

And I've confirmed that when I run the generator with these changes, it's a no-op. It reports "nothing to commit, working tree clean".