### PR TITLE
Use glean-core as default dependency

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -27,7 +27,7 @@ class GleanPing(GenericPing):
     repos_url = GenericPing.probe_info_base_url + "/glean/repositories"
     dependencies_url_template = GenericPing.probe_info_base_url + "/glean/{}/dependencies"
 
-    default_dependencies = ['glean']
+    default_dependencies = ['glean-core']
 
     def __init__(self, repo, app_id, **kwargs):  # TODO: Make env-url optional
         self.repo = repo

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -28,7 +28,6 @@ class GleanPing(GenericPing):
     dependencies_url_template = GenericPing.probe_info_base_url + "/glean/{}/dependencies"
 
     default_dependencies = ['glean']
-    ignore_pings = {"all-pings", "all_pings", "default", "glean_ping_info", "glean_client_info"}
 
     def __init__(self, repo, app_id, **kwargs):  # TODO: Make env-url optional
         self.repo = repo


### PR DESCRIPTION
At this point, there are no repositories using the default dependency, so this shouldn't change anything.