### PR TITLE
Set default branch in commands to track mozilla-pipeline-schemas

### DIFF
--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -23,42 +23,60 @@ CONFIGS_DIR = ROOT_DIR / "configs"
 SCHEMA_NAME_RE = re.compile(r".+/([a-zA-Z0-9_-]+)\.([0-9]+)\.schema\.json")
 
 
+def _apply_options(func, options):
+    """Apply options to a command."""
+    for option in options:
+        func = option(func)
+    return func
+
+
+def common_options(func):
+    """Common options for schema generator commands."""
+    return _apply_options(
+        func,
+        [
+            click.option(
+                "--out-dir",
+                help=(
+                    "The directory to write the schema files to. "
+                    "If not provided, writes the schemas to stdout."
+                ),
+                type=click.Path(dir_okay=True, file_okay=False, writable=True),
+                required=False,
+            ),
+            click.option(
+                "--split",
+                is_flag=True,
+                help=("If provided, splits the schema into " "smaller sub-schemas"),
+            ),
+            click.option(
+                "--pretty",
+                is_flag=True,
+                help=(
+                    "If specified, pretty-prints the JSON "
+                    "schemas that are outputted. Otherwise "
+                    "the schemas will be on one line."
+                ),
+            ),
+            click.option(
+                "--mps-branch",
+                help=(
+                    "If specified, the source branch of "
+                    "mozilla-pipeline-schemas to reference"
+                ),
+                required=False,
+            ),
+        ],
+    )
+
+
 @click.command()
 @click.argument(
     "config",
     type=click.Path(dir_okay=False, file_okay=True, writable=False, exists=True),
     default=CONFIGS_DIR / "main.yaml",
 )
-@click.option(
-    "--out-dir",
-    help=(
-        "The directory to write the schema files to. "
-        "If not provided, writes the schemas to stdout."
-    ),
-    type=click.Path(dir_okay=True, file_okay=False, writable=True),
-    required=False,
-)
-@click.option(
-    "--split",
-    is_flag=True,
-    help=("If provided, splits the schema into " "smaller sub-schemas"),
-)
-@click.option(
-    "--pretty",
-    is_flag=True,
-    help=(
-        "If specified, pretty-prints the JSON "
-        "schemas that are outputted. Otherwise "
-        "the schemas will be on one line."
-    ),
-)
-@click.option(
-    "--mps-branch",
-    help=(
-        "If specified, the source branch of " "mozilla-pipeline-schemas to reference"
-    ),
-    required=False,
-)
+@common_options
 def generate_main_ping(config, out_dir, split, pretty, mps_branch):
     schema_generator = MainPing(mps_branch=mps_branch)
     if out_dir:
@@ -78,29 +96,7 @@ def generate_main_ping(config, out_dir, split, pretty, mps_branch):
     type=click.Path(dir_okay=True, file_okay=False, writable=False, exists=True),
     default=CONFIGS_DIR,
 )
-@click.option(
-    "--out-dir",
-    help=(
-        "The directory to write the schema files to. "
-        "If not provided, writes the schemas to stdout."
-    ),
-    type=click.Path(dir_okay=True, file_okay=False, writable=True),
-    required=False,
-)
-@click.option(
-    "--split",
-    is_flag=True,
-    help=("If provided, splits the schema into " "smaller sub-schemas"),
-)
-@click.option(
-    "--pretty",
-    is_flag=True,
-    help=(
-        "If specified, pretty-prints the JSON "
-        "schemas that are outputted. Otherwise "
-        "the schemas will be on one line."
-    ),
-)
+@common_options
 @click.option(
     "--common-pings-config",
     default="common_pings.json",
@@ -109,15 +105,8 @@ def generate_main_ping(config, out_dir, split, pretty, mps_branch):
         "of pings in the common ping format."
     ),
 )
-@click.option(
-    "--mps-branch",
-    help=(
-        "If specified, the source branch of " "mozilla-pipeline-schemas to reference"
-    ),
-    required=False,
-)
 def generate_common_pings(
-    config_dir, out_dir, split, pretty, common_pings_config, mps_branch
+    config_dir, out_dir, split, pretty, mps_branch, common_pings_config
 ):
     if split:
         raise NotImplementedError("Splitting of common pings is not yet supported.")
@@ -155,29 +144,7 @@ def generate_common_pings(
     type=click.Path(dir_okay=False, file_okay=True, writable=False, exists=True),
     default=CONFIGS_DIR / "glean.yaml",
 )
-@click.option(
-    "--out-dir",
-    help=(
-        "The directory to write the schema files to. "
-        "If not provided, writes the schemas to stdout."
-    ),
-    type=click.Path(dir_okay=True, file_okay=False, writable=True),
-    required=False,
-)
-@click.option(
-    "--split",
-    is_flag=True,
-    help=("If provided, splits the schema into " "smaller sub-schemas"),
-)
-@click.option(
-    "--pretty",
-    is_flag=True,
-    help=(
-        "If specified, pretty-prints the JSON "
-        "schemas that are outputted. Otherwise "
-        "the schemas will be on one line."
-    ),
-)
+@common_options
 @click.option(
     "--repo",
     help=(
@@ -197,15 +164,8 @@ def generate_common_pings(
         "every application's glean pings."
     ),
 )
-@click.option(
-    "--mps-branch",
-    help=(
-        "If specified, the source branch of " "mozilla-pipeline-schemas to reference"
-    ),
-    required=False,
-)
 def generate_glean_pings(
-    config, out_dir, split, pretty, repo, generic_schema, mps_branch
+    config, out_dir, split, pretty, mps_branch, repo, generic_schema
 ):
     if split:
         raise NotImplementedError("Splitting of Glean pings is not yet supported.")

--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -65,6 +65,8 @@ def common_options(func):
                     "mozilla-pipeline-schemas to reference"
                 ),
                 required=False,
+                type=str,
+                default="master",
             ),
         ],
     )

--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -4,17 +4,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import click
-import sys
-import yaml
 import json
 import re
+import sys
 from pathlib import Path
 
+import click
+import yaml
+
 from .common_ping import CommonPing
-from .main_ping import MainPing
-from .glean_ping import GleanPing
 from .config import Config
+from .glean_ping import GleanPing
+from .main_ping import MainPing
 from .schema import SchemaEncoder
 
 ROOT_DIR = Path(__file__).parent
@@ -24,43 +25,38 @@ SCHEMA_NAME_RE = re.compile(r".+/([a-zA-Z0-9_-]+)\.([0-9]+)\.schema\.json")
 
 @click.command()
 @click.argument(
-    'config',
-    type=click.Path(
-        dir_okay=False,
-        file_okay=True,
-        writable=False,
-        exists=True,
-    ),
+    "config",
+    type=click.Path(dir_okay=False, file_okay=True, writable=False, exists=True),
     default=CONFIGS_DIR / "main.yaml",
 )
 @click.option(
-    '--out-dir',
-    help=("The directory to write the schema files to. "
-          "If not provided, writes the schemas to stdout."),
-    type=click.Path(
-        dir_okay=True,
-        file_okay=False,
-        writable=True,
+    "--out-dir",
+    help=(
+        "The directory to write the schema files to. "
+        "If not provided, writes the schemas to stdout."
     ),
-    required=False
+    type=click.Path(dir_okay=True, file_okay=False, writable=True),
+    required=False,
 )
 @click.option(
-    '--split',
+    "--split",
     is_flag=True,
-    help=("If provided, splits the schema into "
-          "smaller sub-schemas"),
+    help=("If provided, splits the schema into " "smaller sub-schemas"),
 )
 @click.option(
-    '--pretty',
+    "--pretty",
     is_flag=True,
-    help=("If specified, pretty-prints the JSON "
-          "schemas that are outputted. Otherwise "
-          "the schemas will be on one line."),
+    help=(
+        "If specified, pretty-prints the JSON "
+        "schemas that are outputted. Otherwise "
+        "the schemas will be on one line."
+    ),
 )
 @click.option(
-    '--mps-branch',
-    help=("If specified, the source branch of "
-          "mozilla-pipeline-schemas to reference"),
+    "--mps-branch",
+    help=(
+        "If specified, the source branch of " "mozilla-pipeline-schemas to reference"
+    ),
     required=False,
 )
 def generate_main_ping(config, out_dir, split, pretty, mps_branch):
@@ -68,7 +64,7 @@ def generate_main_ping(config, out_dir, split, pretty, mps_branch):
     if out_dir:
         out_dir = Path(out_dir)
 
-    with open(config, 'r') as f:
+    with open(config, "r") as f:
         config_data = yaml.safe_load(f)
 
     config = Config("main", config_data)
@@ -78,52 +74,51 @@ def generate_main_ping(config, out_dir, split, pretty, mps_branch):
 
 @click.command()
 @click.argument(
-    'config-dir',
-    type=click.Path(
-        dir_okay=True,
-        file_okay=False,
-        writable=False,
-        exists=True,
-    ),
+    "config-dir",
+    type=click.Path(dir_okay=True, file_okay=False, writable=False, exists=True),
     default=CONFIGS_DIR,
 )
 @click.option(
-    '--out-dir',
-    help=("The directory to write the schema files to. "
-          "If not provided, writes the schemas to stdout."),
-    type=click.Path(
-        dir_okay=True,
-        file_okay=False,
-        writable=True,
+    "--out-dir",
+    help=(
+        "The directory to write the schema files to. "
+        "If not provided, writes the schemas to stdout."
     ),
-    required=False
-)
-@click.option(
-    '--split',
-    is_flag=True,
-    help=("If provided, splits the schema into "
-          "smaller sub-schemas"),
-)
-@click.option(
-    '--pretty',
-    is_flag=True,
-    help=("If specified, pretty-prints the JSON "
-          "schemas that are outputted. Otherwise "
-          "the schemas will be on one line."),
-)
-@click.option(
-    '--common-pings-config',
-    default="common_pings.json",
-    help=("File containing URLs to schemas and configs "
-          "of pings in the common ping format."),
-)
-@click.option(
-    '--mps-branch',
-    help=("If specified, the source branch of "
-          "mozilla-pipeline-schemas to reference"),
+    type=click.Path(dir_okay=True, file_okay=False, writable=True),
     required=False,
 )
-def generate_common_pings(config_dir, out_dir, split, pretty, common_pings_config, mps_branch):
+@click.option(
+    "--split",
+    is_flag=True,
+    help=("If provided, splits the schema into " "smaller sub-schemas"),
+)
+@click.option(
+    "--pretty",
+    is_flag=True,
+    help=(
+        "If specified, pretty-prints the JSON "
+        "schemas that are outputted. Otherwise "
+        "the schemas will be on one line."
+    ),
+)
+@click.option(
+    "--common-pings-config",
+    default="common_pings.json",
+    help=(
+        "File containing URLs to schemas and configs "
+        "of pings in the common ping format."
+    ),
+)
+@click.option(
+    "--mps-branch",
+    help=(
+        "If specified, the source branch of " "mozilla-pipeline-schemas to reference"
+    ),
+    required=False,
+)
+def generate_common_pings(
+    config_dir, out_dir, split, pretty, common_pings_config, mps_branch
+):
     if split:
         raise NotImplementedError("Splitting of common pings is not yet supported.")
 
@@ -132,7 +127,7 @@ def generate_common_pings(config_dir, out_dir, split, pretty, common_pings_confi
 
     common_pings = []
 
-    with open(common_pings_config, 'r') as f:
+    with open(common_pings_config, "r") as f:
         common_pings = json.load(f)
 
     for common_ping in common_pings:
@@ -141,7 +136,7 @@ def generate_common_pings(config_dir, out_dir, split, pretty, common_pings_confi
         config_data = {}
 
         if "config" in common_ping:
-            with open(config_dir / common_ping["config"], 'r') as f:
+            with open(config_dir / common_ping["config"], "r") as f:
                 config_data = yaml.safe_load(f)
 
         m = re.match(SCHEMA_NAME_RE, common_ping["schema_url"])
@@ -156,61 +151,62 @@ def generate_common_pings(config_dir, out_dir, split, pretty, common_pings_confi
 
 @click.command()
 @click.argument(
-    'config',
-    type=click.Path(
-        dir_okay=False,
-        file_okay=True,
-        writable=False,
-        exists=True,
-    ),
+    "config",
+    type=click.Path(dir_okay=False, file_okay=True, writable=False, exists=True),
     default=CONFIGS_DIR / "glean.yaml",
 )
 @click.option(
-    '--out-dir',
-    help=("The directory to write the schema files to. "
-          "If not provided, writes the schemas to stdout."),
-    type=click.Path(
-        dir_okay=True,
-        file_okay=False,
-        writable=True,
+    "--out-dir",
+    help=(
+        "The directory to write the schema files to. "
+        "If not provided, writes the schemas to stdout."
     ),
-    required=False
-)
-@click.option(
-    '--split',
-    is_flag=True,
-    help=("If provided, splits the schema into "
-          "smaller sub-schemas"),
-)
-@click.option(
-    '--pretty',
-    is_flag=True,
-    help=("If specified, pretty-prints the JSON "
-          "schemas that are outputted. Otherwise "
-          "the schemas will be on one line."),
-)
-@click.option(
-    '--repo',
-    help=("The repository id to write the schemas of. "
-          "If not specified, writes the schemas of all "
-          "repositories."),
-    required=False,
-    type=str
-)
-@click.option(
-    '--generic-schema',
-    is_flag=True,
-    help=("When specified, schemas are not filled in, "
-          "but instead the generic schema is used for "
-          "every application's glean pings.")
-)
-@click.option(
-    '--mps-branch',
-    help=("If specified, the source branch of "
-          "mozilla-pipeline-schemas to reference"),
+    type=click.Path(dir_okay=True, file_okay=False, writable=True),
     required=False,
 )
-def generate_glean_pings(config, out_dir, split, pretty, repo, generic_schema, mps_branch):
+@click.option(
+    "--split",
+    is_flag=True,
+    help=("If provided, splits the schema into " "smaller sub-schemas"),
+)
+@click.option(
+    "--pretty",
+    is_flag=True,
+    help=(
+        "If specified, pretty-prints the JSON "
+        "schemas that are outputted. Otherwise "
+        "the schemas will be on one line."
+    ),
+)
+@click.option(
+    "--repo",
+    help=(
+        "The repository id to write the schemas of. "
+        "If not specified, writes the schemas of all "
+        "repositories."
+    ),
+    required=False,
+    type=str,
+)
+@click.option(
+    "--generic-schema",
+    is_flag=True,
+    help=(
+        "When specified, schemas are not filled in, "
+        "but instead the generic schema is used for "
+        "every application's glean pings."
+    ),
+)
+@click.option(
+    "--mps-branch",
+    help=(
+        "If specified, the source branch of " "mozilla-pipeline-schemas to reference"
+    ),
+    required=False,
+)
+def generate_glean_pings(
+    config, out_dir, split, pretty, repo, generic_schema, mps_branch
+):
     if split:
         raise NotImplementedError("Splitting of Glean pings is not yet supported.")
 
@@ -222,31 +218,40 @@ def generate_glean_pings(config, out_dir, split, pretty, repo, generic_schema, m
     if repo is not None:
         repos = [(r_name, r_id) for r_name, r_id in repos if r_id == repo]
 
-    with open(config, 'r') as f:
+    with open(config, "r") as f:
         config_data = yaml.safe_load(f)
 
     config = Config("glean", config_data)
 
     for repo_name, repo_id in repos:
-        write_schema(repo_name, repo_id, config, out_dir, split, pretty, generic_schema, mps_branch)
+        write_schema(
+            repo_name,
+            repo_id,
+            config,
+            out_dir,
+            split,
+            pretty,
+            generic_schema,
+            mps_branch,
+        )
 
 
-def write_schema(repo, repo_id, config, out_dir, split, pretty, generic_schema, mps_branch):
+def write_schema(
+    repo, repo_id, config, out_dir, split, pretty, generic_schema, mps_branch
+):
     schema_generator = GleanPing(repo, repo_id, mps_branch=mps_branch)
-    schemas = schema_generator.generate_schema(config, split=False, generic_schema=generic_schema)
+    schemas = schema_generator.generate_schema(
+        config, split=False, generic_schema=generic_schema
+    )
     dump_schema(schemas, out_dir and out_dir.joinpath(repo_id), pretty)
 
 
 def dump_schema(schemas, out_dir, pretty, *, version=1):
-    json_dump_args = {
-        'cls': SchemaEncoder
-    }
+    json_dump_args = {"cls": SchemaEncoder}
     if pretty:
-        json_dump_args.update({
-            'indent': 4,
-            'separators': (',', ':'),
-            'sort_keys': True,
-        })
+        json_dump_args.update(
+            {"indent": 4, "separators": (",", ":"), "sort_keys": True}
+        )
 
     if not out_dir:
         print(json.dumps(schemas, **json_dump_args))
@@ -255,7 +260,7 @@ def dump_schema(schemas, out_dir, pretty, *, version=1):
         for name, _schemas in schemas.items():
             # Bug 1601270; we transform ping names from snake_case to kebab-case;
             # we can remove this line once all snake_case probes have converted.
-            name = name.replace('_', '-')
+            name = name.replace("_", "-")
             ping_out_dir = out_dir.joinpath(name)
             if not ping_out_dir.exists():
                 ping_out_dir.mkdir(parents=True)
@@ -265,7 +270,7 @@ def dump_schema(schemas, out_dir, pretty, *, version=1):
 
             schema = _schemas[0]
             fname = ping_out_dir.joinpath("{}.{}.schema.json".format(name, version))
-            with open(fname, 'w') as f:
+            with open(fname, "w") as f:
                 f.write(json.dumps(schema, **json_dump_args))
 
 
@@ -273,6 +278,7 @@ def dump_schema(schemas, out_dir, pretty, *, version=1):
 def main(args=None):
     """Command line utility for mozilla-schema-generator."""
     import logging
+
     logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 
 


### PR DESCRIPTION
This fixes #160 by setting the default branch to `master`. The `__main__` entrypoint is formatted and refactored so the default is set in a single place.