### PR TITLE
Bug 1672448 Persist Glean retention_days setting to generated schema

### DIFF
--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -178,17 +178,16 @@ def generate_glean_pings(
     repos = GleanPing.get_repos()
 
     if repo is not None:
-        repos = [(r_name, r_id) for r_name, r_id in repos if r_id == repo]
+        repos = [r for r in repos if r["app_id"] == repo]
 
     with open(config, "r") as f:
         config_data = yaml.safe_load(f)
 
     config = Config("glean", config_data)
 
-    for repo_name, repo_id in repos:
+    for repo in repos:
         write_schema(
-            repo_name,
-            repo_id,
+            repo,
             config,
             out_dir,
             split,
@@ -199,13 +198,13 @@ def generate_glean_pings(
 
 
 def write_schema(
-    repo, repo_id, config, out_dir, split, pretty, generic_schema, mps_branch
+    repo, config, out_dir, split, pretty, generic_schema, mps_branch
 ):
-    schema_generator = GleanPing(repo, repo_id, mps_branch=mps_branch)
+    schema_generator = GleanPing(repo, mps_branch=mps_branch)
     schemas = schema_generator.generate_schema(
         config, split=False, generic_schema=generic_schema
     )
-    dump_schema(schemas, out_dir and out_dir.joinpath(repo_id), pretty)
+    dump_schema(schemas, out_dir and out_dir.joinpath(repo["app_id"]), pretty)
 
 
 def dump_schema(schemas, out_dir, pretty, *, version=1):

--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -197,9 +197,7 @@ def generate_glean_pings(
         )
 
 
-def write_schema(
-    repo, config, out_dir, split, pretty, generic_schema, mps_branch
-):
+def write_schema(repo, config, out_dir, split, pretty, generic_schema, mps_branch):
     schema_generator = GleanPing(repo, mps_branch=mps_branch)
     schemas = schema_generator.generate_schema(
         config, split=False, generic_schema=generic_schema

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -169,9 +169,7 @@ class GleanPing(GenericPing):
                 expiration["delete_after_days"] = int(retention_days)
                 pipeline_meta["expiration_policy"] = expiration
 
-            defaults = {
-                "mozPipelineMetadata": pipeline_meta
-            }
+            defaults = {"mozPipelineMetadata": pipeline_meta}
 
             if generic_schema:  # Use the generic glean ping schema
                 schema = self.get_schema()
@@ -192,8 +190,4 @@ class GleanPing(GenericPing):
         Retrieve metadata for all non-library Glean repositories
         """
         repos = GleanPing._get_json(GleanPing.repos_url)
-        return [
-            repo
-            for repo in repos
-            if "library_names" not in repo
-        ]
+        return [repo for repo in repos if "library_names" not in repo]

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -39,13 +39,14 @@ class GleanPing(GenericPing):
         "glean_client_info",
     }
 
-    def __init__(self, repo, app_id, **kwargs):  # TODO: Make env-url optional
+    def __init__(self, repo, **kwargs):  # TODO: Make env-url optional
         self.repo = repo
-        self.app_id = app_id
+        self.repo_name = repo["name"]
+        self.app_id = repo["app_id"]
         super().__init__(
             self.schema_url,
             self.schema_url,
-            self.probes_url_template.format(repo),
+            self.probes_url_template.format(self.repo_name),
             **kwargs,
         )
 
@@ -57,10 +58,10 @@ class GleanPing(GenericPing):
         # map those back to the name of the repository in the repository file.
         try:
             dependencies = self._get_json(
-                self.dependencies_url_template.format(self.repo)
+                self.dependencies_url_template.format(self.repo_name)
             )
         except HTTPError:
-            logging.info(f"For {self.repo}, using default Glean dependencies")
+            logging.info(f"For {self.repo_name}, using default Glean dependencies")
             return self.default_dependencies
 
         dependency_library_names = list(dependencies.keys())
@@ -77,10 +78,10 @@ class GleanPing(GenericPing):
                 dependencies.append(repos_by_dependency_name[name])
 
         if len(dependencies) == 0:
-            logging.info(f"For {self.repo}, using default Glean dependencies")
+            logging.info(f"For {self.repo_name}, using default Glean dependencies")
             return self.default_dependencies
 
-        logging.info(f"For {self.repo}, found Glean dependencies: {dependencies}")
+        logging.info(f"For {self.repo_name}, found Glean dependencies: {dependencies}")
         return dependencies
 
     def get_probes(self) -> List[GleanProbe]:
@@ -109,7 +110,7 @@ class GleanPing(GenericPing):
                 "firefox-android-release",
             }
             if (
-                self.repo in issue_118_affected
+                self.repo_name in issue_118_affected
                 and probe.get_name() == "installation.timestamp"
             ):
                 logging.info(f"Writing column {probe.get_name()} for compatibility.")
@@ -134,7 +135,7 @@ class GleanPing(GenericPing):
         return processed
 
     def get_pings(self) -> Set[str]:
-        url = self.ping_url_template.format(self.repo)
+        url = self.ping_url_template.format(self.repo_name)
         pings = GleanPing._get_json(url).keys()
 
         for dependency in self.get_dependencies():
@@ -156,13 +157,20 @@ class GleanPing(GenericPing):
             for matcher in matchers.values():
                 matcher.matcher["send_in_pings"]["contains"] = ping
             new_config = Config(ping, matchers=matchers)
+            retention_days = self.repo.get("retention_days", None)
+
+            pipeline_meta = {
+                "bq_dataset_family": self.app_id.replace("-", "_"),
+                "bq_table": ping.replace("-", "_") + "_v1",
+                "bq_metadata_format": "structured",
+            }
+            if retention_days is not None:
+                expiration = pipeline_meta.get("expiration_policy", {})
+                expiration["delete_after_days"] = int(retention_days)
+                pipeline_meta["expiration_policy"] = expiration
 
             defaults = {
-                "mozPipelineMetadata": {
-                    "bq_dataset_family": self.app_id.replace("-", "_"),
-                    "bq_table": ping.replace("-", "_") + "_v1",
-                    "bq_metadata_format": "structured",
-                }
+                "mozPipelineMetadata": pipeline_meta
             }
 
             if generic_schema:  # Use the generic glean ping schema
@@ -181,11 +189,11 @@ class GleanPing(GenericPing):
     @staticmethod
     def get_repos():
         """
-        Retrieve name and app_id for Glean repositories
+        Retrieve metadata for all non-library Glean repositories
         """
         repos = GleanPing._get_json(GleanPing.repos_url)
         return [
-            (repo["name"], repo["app_id"])
+            repo
             for repo in repos
             if "library_names" not in repo
         ]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ readme = open("README.md").read()
 setup(
     name="mozilla-schema-generator",
     python_requires=">=3.6.0",
-    version="0.2.0",
+    version="0.3.0",
     description="Create full representations of schemas using the probe info service.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -19,7 +19,7 @@ from .test_utils import print_and_test
 
 @pytest.fixture
 def glean():
-    return glean_ping.GleanPing({"name": "glean", "app_id:": "org-mozilla-glean"})
+    return glean_ping.GleanPing({"name": "glean", "app_id": "org-mozilla-glean"})
 
 
 @pytest.fixture

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -84,3 +84,16 @@ class TestGleanPing(object):
         not_glean = NoProbeGleanPing(repo)
         with pytest.raises(requests.exceptions.HTTPError):
             not_glean.generate_schema(config, split=False)
+
+    def test_retention_days(self, config):
+        glean = glean_ping.GleanPing(
+            {"name": "glean", "app_id": "org-mozilla-glean", "retention_days": 90}
+        )
+        schemas = glean.generate_schema(config, split=False, generic_schema=True)
+
+        final_schemas = {k: schemas[k][0].schema for k in schemas}
+        for name, schema in final_schemas.items():
+            assert (
+                schema["mozPipelineMetadata"]["expiration_policy"]["delete_after_days"]
+                == 90
+            )

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -19,7 +19,7 @@ from .test_utils import print_and_test
 
 @pytest.fixture
 def glean():
-    return glean_ping.GleanPing("glean", "org-mozilla-glean")
+    return glean_ping.GleanPing({"name": "glean", "app_id:": "org-mozilla-glean"})
 
 
 @pytest.fixture
@@ -61,7 +61,8 @@ class TestGleanPing(object):
 
     def test_get_repos(self):
         repos = glean_ping.GleanPing.get_repos()
-        assert ("fenix", "org-mozilla-fenix") in repos
+        names_ids = [(r["name"], r["app_id"]) for r in repos]
+        assert ("fenix", "org-mozilla-fenix") in names_ids
 
     def test_generic_schema(self, glean, config):
         schemas = glean.generate_schema(config, split=False, generic_schema=True)
@@ -79,7 +80,7 @@ class TestGleanPing(object):
 
     def test_missing_data(self, config):
         # When there are no files, this should error
-
-        not_glean = NoProbeGleanPing("LeanGleanPingNoIding", "org-mozilla-lean")
+        repo = {"name": "LeanGleanPingNoIding", "app_id": "org-mozilla-lean"}
+        not_glean = NoProbeGleanPing(repo)
         with pytest.raises(requests.exceptions.HTTPError):
             not_glean.generate_schema(config, split=False)


### PR DESCRIPTION
This translates the `retention_days` setting from Glean repositories.yaml
to `mozPipelineMetadata.expiration_policy.delete_after_days` in all generated
JSON schemas for the application.

We will need a further step in the ops logic to act on this schema-level
metadata, setting the appropriate table-level retention policy in BQ.