### PR TITLE
Bug 1682627 - Support propagating schema incompatible changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,30 @@ This specific field is for indicating which table group that section of the ping
 splitting the schema. Currently we do not split any pings. See the section on [BigQuery
 Limitations and Splitting](#bigquery-limitations-and-splitting) for more info.
 
+## Allowing schema incompatible changes
+
+On every run of the schema generator, there is a check for incompatible changes
+between the previous revision and current generated revision. A schema
+incompatible change includes a removal of a schema or a column, or a change in
+the type definition of a column.
+
+There are two methods to get around these restrictions. If you are actively
+developing the schema generator and need to introduce a schema incompatible
+change, set `MPS_VALIDATE_BQ=false`.
+
+If a schema incompatible change needs to be introduced in production (i.e.
+`generated-schemas`), then modify the `incompatibility-allowlist` at the root of
+the repository. Add documents in the form of
+`{namespace}.{doctype}.{docversion}`. Globs are allowed. For example, add the
+following line to allow remove schemas under the `my_glean_app` namespace:
+
+```bash
+my_glean_app.*
+```
+
+Once the commit has gone through successfully, this line should be removed from
+the document.
+
 ## Development and Testing
 
 Install requirements:

--- a/deletion-allowlist
+++ b/deletion-allowlist
@@ -1,0 +1,7 @@
+# The deletion-allowlist is meant to circumvent schema validation when removing
+# schemas from the schema repository. To use this, add a line that matches the
+# convention `{namespace}.{doctype}.{docversion}`. Globs may be used. This is
+# is only required for commits that introduce a schema deletion.
+
+# Example:
+# telemetry.untrustedModules.*

--- a/deletion-allowlist
+++ b/deletion-allowlist
@@ -1,7 +1,0 @@
-# The deletion-allowlist is meant to circumvent schema validation when removing
-# schemas from the schema repository. To use this, add a line that matches the
-# convention `{namespace}.{doctype}.{docversion}`. Globs may be used. This is
-# is only required for commits that introduce a schema deletion.
-
-# Example:
-# telemetry.untrustedModules.*

--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -1,0 +1,8 @@
+# The incompatibility-allowlist is meant to circumvent schema validation when
+# removing schemas from the schema repository. To use this, add a line that
+# matches the convention `{namespace}.{doctype}.{docversion}`. Globs may be used.
+# This is is only required for commits that introduce a schema deletion or allow
+# for incompatible changes in columns.
+
+# Example:
+# telemetry.untrustedModules.*

--- a/mozilla_schema_generator/validate_bigquery.py
+++ b/mozilla_schema_generator/validate_bigquery.py
@@ -139,7 +139,7 @@ def validate():
     "--deletion-allowlist",
     type=click.Path(dir_okay=False),
     help="newline delimited globs of schemas that are allowed to be removed",
-    default=None,
+    default=BASE_DIR / "mozilla-schema-generator/deletion-allowlist",
 )
 def local_validation(head, base, repository, artifact, deletion_allowlist):
     """Validate schemas using a heuristic from the compact schemas."""

--- a/tests/test_validate_bigquery.py
+++ b/tests/test_validate_bigquery.py
@@ -27,6 +27,9 @@ def tmp_git(tmp_path):
     repo = Repo(path)
     repo.git.checkout("master")
     repo.git.checkout("generated-schemas")
+    # set config for ci
+    repo.git.config("user.email", "test@test.com")
+    repo.git.config("user.name", "test")
     return path
 
 


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1682627)

This adds support for a incompatibility-allowlist that allows for deletions or schema incompatible changes. This is done by omitting the document from the base revision. The entries only need to exist in the allowlist for the single commit (and should probably be removed afterwards). 

