### PR TITLE
Fix #102 - Add readme for generated-schemas branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN groupadd --gid ${USER_ID} ${GROUP_ID} && \
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        file gcc libwww-perl && \
+        file gcc tree libwww-perl && \
     apt-get autoremove -y && \
     apt-get clean
 

--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Utility functions for processing schemas.
-set +e
+set -e
 
 # NOTE: mozilla-schema-generator resources are relative to this script. See
 # http://mywiki.wooledge.org/BashFAQ/028 on uses of BASH_SOURCE. This needs to
@@ -108,25 +108,21 @@ function _create_changelog() {
         --date=iso
 }
 
-function _create_readme(){
-
-    local title=$1
-    local summary=$2
-    
-    local tree=$(tree )
-
+function _create_readme() {
     cat << EOF > README.md
-    ## $title
+# \`generated-schemas\`
 
-    ### Summary: 
+## Directory tree
 
-    $summary
+\`\`\`bash
+$(tree)
+\`\`\`
 
-    ### Directory tree: 
-    ${tree}
+## Last 20 commits
 
-    ### Last month's commit Logs: 
-     
+\`\`\`bash
+$(_create_changelog master~20)
+\`\`\`
 EOF
 }
 
@@ -161,23 +157,19 @@ function _commit_schemas() {
         --generic-schema \
         --mps-branch "$mps_branch_source" \
         --out-dir schemas
-    _create_readme "Generated Schemas" \
-        "Create the JSON Schema in the templates directory first. Make use of common schema components
-    from the templates/include directory where possible, including things like the telemetry environment,
-    clientId, application block, or UUID patterns. 
-    The filename should be templates/<namespace>/<doctype>/<doctype>.<version>.schema.json"
 
-    
+    _create_readme
+
     git log --since="last month" --pretty=format:'%h : %s by %an' --graph >> README.md
 
     find . -name "*.schema.json" -type f -exec git add {} +
     find . -name "*.md" -type f -exec git add {} +
-    
+
     git commit -a -m "Interim Commit"
 
     git checkout "$mps_branch_publish" || git checkout -b "$mps_branch_publish"
 
-    # Keep only the schemas dir and Readme
+    # Keep only the schemas dir and readme
     find . -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
     git checkout "$mps_branch_working" -- schemas README.md
     git commit --all \

--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -109,15 +109,13 @@ function _create_changelog() {
 }
 
 function _create_readme(){
-    
-    if [ -e README.md ]; then
-        echo "File README.md already exists!"
-    else
-        echo "iam here"
-        echo "### Title1 $1" > README.md
-        echo "#### Description/ summary: $2" >> README.md
-        echo "#### commit log for the last month: $3" >> README.md
-    fi
+    local title=$1
+    local summary=$2
+    local logs=$3
+    cat << EOF > testREADME.md
+    Title: "$title"
+    Summary : "$summary"
+EOF
 }
 
 function _commit_schemas() {
@@ -151,9 +149,10 @@ function _commit_schemas() {
         --generic-schema \
         --mps-branch "$mps_branch_source" \
         --out-dir schemas
+    _create_readme
 
     find . -name "*.schema.json" -type f -exec git add {} +
-    find . -name "README.md" -type f -exec git add {} +
+    find . -name "*.md" -type f -exec git add {} +
 
     git commit -a -m "Interim Commit"
 

--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -108,6 +108,18 @@ function _create_changelog() {
         --date=iso
 }
 
+function _create_readme(){
+    
+    if [ -e README.md ]; then
+        echo "File README.md already exists!"
+    else
+        echo "iam here"
+        echo "### Title1 $1" > README.md
+        echo "#### Description/ summary: $2" >> README.md
+        echo "#### commit log for the last month: $3" >> README.md
+    fi
+}
+
 function _commit_schemas() {
     # Commit schemas in the current branch to the publish branch.
     local mps_root=${1?must provide path to mozilla-pipeline-schemas repository}
@@ -141,6 +153,7 @@ function _commit_schemas() {
         --out-dir schemas
 
     find . -name "*.schema.json" -type f -exec git add {} +
+    find . -name "README.md" -type f -exec git add {} +
 
     git commit -a -m "Interim Commit"
 

--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Utility functions for processing schemas.
-set -e
+set +e
 
 # NOTE: mozilla-schema-generator resources are relative to this script. See
 # http://mywiki.wooledge.org/BashFAQ/028 on uses of BASH_SOURCE. This needs to
@@ -109,12 +109,24 @@ function _create_changelog() {
 }
 
 function _create_readme(){
+
     local title=$1
     local summary=$2
-    local logs=$3
-    cat << EOF > testREADME.md
-    Title: "$title"
-    Summary : "$summary"
+    
+    local tree=$(tree )
+
+    cat << EOF > README.md
+    ## $title
+
+    ### Summary: 
+
+    $summary
+
+    ### Directory tree: 
+    ${tree}
+
+    ### Last month's commit Logs: 
+     
 EOF
 }
 
@@ -149,18 +161,25 @@ function _commit_schemas() {
         --generic-schema \
         --mps-branch "$mps_branch_source" \
         --out-dir schemas
-    _create_readme
+    _create_readme "Generated Schemas" \
+        "Create the JSON Schema in the templates directory first. Make use of common schema components
+    from the templates/include directory where possible, including things like the telemetry environment,
+    clientId, application block, or UUID patterns. 
+    The filename should be templates/<namespace>/<doctype>/<doctype>.<version>.schema.json"
+
+    
+    git log --since="last month" --pretty=format:'%h : %s by %an' --graph >> README.md
 
     find . -name "*.schema.json" -type f -exec git add {} +
     find . -name "*.md" -type f -exec git add {} +
-
+    
     git commit -a -m "Interim Commit"
 
     git checkout "$mps_branch_publish" || git checkout -b "$mps_branch_publish"
 
-    # Keep only the schemas dir
+    # Keep only the schemas dir and Readme
     find . -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
-    git checkout "$mps_branch_working" -- schemas
+    git checkout "$mps_branch_working" -- schemas README.md
     git commit --all \
         --message "Auto-push from schema generation [ci skip]" \
         --message "$(_create_changelog "$mps_branch_source" "$mps_branch_publish")" \

--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -109,20 +109,28 @@ function _create_changelog() {
 }
 
 function _create_readme() {
+    # date 28 days ago
+    start_date=$(python3 -c "import datetime as dt; print(str(dt.datetime.now()-dt.timedelta(28))[:10])")
     cat << EOF > README.md
-# \`generated-schemas\`
+# mozilla-pipeline-schemas: generated-schemas
 
-## Directory tree
+This is the [generated-schemas](https://github.com/mozilla-services/mozilla-pipeline-schemas/commits/test-generated-schemas)
+branch of [mozilla-pipeline-schemas](https://github.com/mozilla-services/mozilla-pipeline-schemas).
+See the [mps-deploys](https://protosaur.dev/mps-deploys/) dashboard for deployment status of schemas
+to [gcp-ingestion](https://github.com/mozilla/gcp-ingestion) and BigQuery.
+
+## commits in the last 28 days
 
 \`\`\`bash
-$(tree)
+$(git log master --since=${start_date} --pretty=format:"%h%x09%cd%x09%s" --date=iso)
 \`\`\`
 
-## Last 20 commits
+## directory tree
 
 \`\`\`bash
-$(_create_changelog master~20)
+$(tree -d schemas)
 \`\`\`
+
 EOF
 }
 
@@ -159,8 +167,6 @@ function _commit_schemas() {
         --out-dir schemas
 
     _create_readme
-
-    git log --since="last month" --pretty=format:'%h : %s by %an' --graph >> README.md
 
     find . -name "*.schema.json" -type f -exec git add {} +
     find . -name "*.md" -type f -exec git add {} +


### PR DESCRIPTION
This fixes #102 and builds on a contribution from #165. The output can be found here: https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/test-generated-schemas#mozilla-pipeline-schemas-generated-schemas