### PR TITLE
Remove commit section in README

### DIFF
--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -117,12 +117,6 @@ branch of [mozilla-pipeline-schemas](https://github.com/mozilla-services/mozilla
 See the [mps-deploys](https://protosaur.dev/mps-deploys/) dashboard for deployment status of schemas
 to [gcp-ingestion](https://github.com/mozilla/gcp-ingestion) and BigQuery.
 
-## last 10 changes
-
-\`\`\`bash
-$(git log master --pretty=format:"%h%x09%cd%x09%s" --date=iso -n 10)
-\`\`\`
-
 ## directory tree
 
 \`\`\`bash


### PR DESCRIPTION
I was thinking about https://github.com/mozilla/mozilla-schema-generator/issues/172 more. Even if we limit to the last N commits in the README in #173, there will still be no-op commits with changes to MPS that don't affect schemas (e.g. documentation or CI changes). If we want more detailed information, we should look to the commit log or the deploy dashboard for this.