### PR TITLE
Bug 1689513 - allow deletion of glean-js-tmp

### DIFF
--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -8,4 +8,4 @@
 # telemetry.untrustedModules.*
 
 # Bug 1689513
-glean_js_tmp.*
+glean-js-tmp.*


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1689513)

#176 used the normalized namespace, instead of the actual namespace name in mozilla-pipeline-schemas.  As per airflow failures:

```
[2021-02-08 23:22:31,455] {pod_launcher.py:156} INFO - b'items removed from the base\n'
[2021-02-08 23:22:31,456] {pod_launcher.py:156} INFO - b'-glean-js-tmp.metrics.1.txt\n'
[2021-02-08 23:22:31,456] {pod_launcher.py:156} INFO - b'-glean-js-tmp.deletion-request.1.txt\n'
[2021-02-08 23:22:31,456] {pod_launcher.py:156} INFO - b'-glean-js-tmp.events.1.txt\n'
[2021-02-08 23:22:31,456] {pod_launcher.py:156} INFO - b'-glean-js-tmp.baseline.1.txt\n'
[2021-02-08 23:22:31,456] {pod_launcher.py:156} INFO - b'\n'
[2021-02-08 23:22:31,457] {pod_launcher.py:156} INFO - b'found incompatible changes\n'
```
