### PR TITLE
Fix location of incompatibility allowlist

### DIFF
--- a/bin/schema_generator.sh
+++ b/bin/schema_generator.sh
@@ -103,6 +103,9 @@ function validated_generate_commit() {
 }
 
 function main() {
+    # show the current package for mozilla-schema-generator
+    echo $(pip freeze | grep mozilla-schema-generator)
+
     pushd .
     # the base directory in the docker container
     cd /app

--- a/mozilla_schema_generator/validate_bigquery.py
+++ b/mozilla_schema_generator/validate_bigquery.py
@@ -137,9 +137,9 @@ def validate():
 )
 @click.option(
     "--incompatibility-allowlist",
-    type=click.Path(dir_okay=False),
+    type=click.Path(dir_okay=False, exists=True),
     help="newline delimited globs of schemas with allowed schema incompatibilities",
-    default=BASE_DIR / "mozilla-schema-generator/incompatibility-exceptions",
+    default=BASE_DIR / "mozilla-schema-generator/incompatibility-allowlist",
 )
 def local_validation(head, base, repository, artifact, incompatibility_allowlist):
     """Validate schemas using a heuristic from the compact schemas."""

--- a/mozilla_schema_generator/validate_bigquery.py
+++ b/mozilla_schema_generator/validate_bigquery.py
@@ -137,7 +137,7 @@ def validate():
 )
 @click.option(
     "--incompatibility-allowlist",
-    type=click.Path(dir_okay=False, exists=True),
+    type=click.Path(dir_okay=False),
     help="newline delimited globs of schemas with allowed schema incompatibilities",
     default=BASE_DIR / "mozilla-schema-generator/incompatibility-allowlist",
 )


### PR DESCRIPTION
Followup to #178.

This sets the correct location of the incompatibility allowlist.  I see the following in test logs after applying the patch.

```
allowing incompatible changes in the following documents:
        glean-js-tmp.events.1.txt
        glean-js-tmp.baseline.1.txt
        glean-js-tmp.deletion-request.1.txt
        glean-js-tmp.metrics.1.txt
```

I also echo the installed package of msg for good measure at the beginning of the script, because it doesn't look like airflow gives the hash of the container being run(?). 

```
git+git@github.com:mozilla/mozilla-schema-generator.git@af8c45676f3d9203f9a18875834aa219a61061f1#egg=mozilla_schema_generator
```