### PR TITLE
Fix broken glean ping tests

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -30,7 +30,7 @@ class GleanPing(GenericPing):
         GenericPing.probe_info_base_url + "/glean/{}/dependencies"
     )
 
-    default_dependencies = ["glean"]
+    default_dependencies = ["glean-core"]
     ignore_pings = {
         "all-pings",
         "all_pings",

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -19,7 +19,7 @@ from .test_utils import print_and_test
 
 @pytest.fixture
 def glean():
-    return glean_ping.GleanPing({"name": "glean", "app_id": "org-mozilla-glean"})
+    return glean_ping.GleanPing({"name": "glean-core", "app_id": "org-mozilla-glean"})
 
 
 @pytest.fixture
@@ -87,7 +87,7 @@ class TestGleanPing(object):
 
     def test_retention_days(self, config):
         glean = glean_ping.GleanPing(
-            {"name": "glean", "app_id": "org-mozilla-glean", "retention_days": 90}
+            {"name": "glean-core", "app_id": "org-mozilla-glean", "retention_days": 90}
         )
         schemas = glean.generate_schema(config, split=False, generic_schema=True)
 


### PR DESCRIPTION
Tests were broken via https://github.com/mozilla/probe-scraper/pull/285 (in particular [the removal of the glean app](https://github.com/mozilla/probe-scraper/pull/285/files#diff-a039c9b63812e8c69d4ad7a53ccb7c5b15f3721aadca48e869ca5653fa7b4229L38-L51)). This also caused related issues filed in https://github.com/mozilla/probe-scraper/issues/293.

While schema generation itself was fine, this broke some of the existing tests that relied on the `glean` application name. This is blocking automatic deploys to dockerhub (e.g. #185).

```
E           requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://probeinfo.telemetry.mozilla.org/glean/glean/pings?t=2021-03-23T18:05:21.174148
```

See: https://app.circleci.com/pipelines/github/mozilla/mozilla-schema-generator/856/workflows/8aa6093e-eeeb-4de9-98d9-ed9328898d69/jobs/1298

This points the default library to `glean-core` and updates the tests appropriately. 

See https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/35b792efc81ab948469c2b043e38d539bc4e736d for a commit while debugging this test failure, which ran without incompatible issues.
