### PR TITLE
Update all default branch references

### DIFF
--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -19,7 +19,7 @@ function _generate_schemas() {
     # transpiled into a BigQuery schema using the jsonschema-transpiler.
 
     local mps_root=${1?must provide path to mozilla-pipeline-schemas repository}
-    local mps_branch_source=${2:-master}
+    local mps_branch_source=${2:-main}
 
     # Set the working directory to the schemas folder.
     pushd .
@@ -92,13 +92,13 @@ function _create_changelog() {
     # https://stackoverflow.com/questions/25563455/how-do-i-get-last-commit-date-from-git-repository
     # https://stackoverflow.com/questions/1441010/the-shortest-possible-output-from-git-log-containing-author-and-date
     # https://git-scm.com/docs/git-log/1.8.0#git-log---daterelativelocaldefaultisorfcshortraw
-    local mps_branch_source=${1:-master}
+    local mps_branch_source=${1:-main}
     local mps_branch_publish=${2:-generated-schemas}
     local start_date
     # NOTES: Since this function is looking at commit dates (such as rebases),
-    # it's best to enforce squash/rebase commits onto the master branch. If this
+    # it's best to enforce squash/rebase commits onto the main branch. If this
     # isn't enforced, it's possible to miss out on certain commits to the
-    # generated branch. Another solution is to generate a tag on master before
+    # generated branch. Another solution is to generate a tag on main before
     # the generator is run. However, the heuristic of using the latest commit
     # date works well enough.
     start_date=$(git log "${mps_branch_publish}" -1 --format=%cd --date=iso)
@@ -129,7 +129,7 @@ EOF
 function _commit_schemas() {
     # Commit schemas in the current branch to the publish branch.
     local mps_root=${1?must provide path to mozilla-pipeline-schemas repository}
-    local mps_branch_source=${2:-master}
+    local mps_branch_source=${2:-main}
     local mps_branch_publish=${3:-generated-schemas}
 
     pushd .
@@ -183,7 +183,7 @@ function generate_commit {
     # branch. The repository will have it's HEAD at tip of the publish branch,
     # ready to be pushed to a remote.
     local mps_root=${1?must provide path to mozilla-pipeline-schemas repository}
-    local mps_branch_source=${2:-master}
+    local mps_branch_source=${2:-main}
     local mps_branch_publish=${3:-generated-schemas}
     local mps_branch_working=${4:-local-working-branch}
 

--- a/bin/schema_generator.sh
+++ b/bin/schema_generator.sh
@@ -9,7 +9,7 @@
 #   MPS_SSH_KEY_BASE64: A base64-encoded ssh secret key with permissions to push
 #                       to mozilla-pipeline-schemas
 #   MPS_REPO_URL:       The URL to the mozilla-pipeline-schemas repository
-#   MPS_BRANCH_SOURCE:  The source branch for generating schemas e.g. master
+#   MPS_BRANCH_SOURCE:  The source branch for generating schemas e.g. main
 #   MPS_BRANCH_PUBLISH: The destination branch for publishing schemas
 #                       e.g. generated-schemas
 #   MPS_VALIDATE_BQ:    Set to 'false' to disable the validation step
@@ -22,7 +22,7 @@ set -e
 set -x
 
 MPS_REPO_URL=${MPS_REPO_URL:-"git@github.com:mozilla-services/mozilla-pipeline-schemas.git"}
-MPS_BRANCH_SOURCE=${MPS_BRANCH_SOURCE:-"master"}
+MPS_BRANCH_SOURCE=${MPS_BRANCH_SOURCE:-"main"}
 MPS_BRANCH_PUBLISH=${MPS_BRANCH_PUBLISH:-"test-generated-schemas"}
 MPS_VALIDATE_BQ=${MPS_VALIDATE_BQ:-"true"}
 BIN="$(realpath ${BASH_SOURCE%/*})"

--- a/bin/test_validate
+++ b/bin/test_validate
@@ -5,8 +5,8 @@
 #
 # Arguments:
 #   $1  The source branch to use a base for generated schemas. For testing, you
-#       may use something like `master~5` to use the 5th revision from the head
-#       of master.
+#       may use something like `main~5` to use the 5th revision from the head
+#       of main.
 #   $2  The publish branch where commits are made with generated schemas. This
 #       will typically be `test-generated-schemas` or `generated-schemas`.
 #   $3  The base branch to use for validation. This is set to $2 by default, but

--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -67,7 +67,7 @@ def common_options(func):
                 ),
                 required=False,
                 type=str,
-                default="master",
+                default="main",
             ),
         ],
     )

--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -25,7 +25,7 @@ class GenericPing(object):
     extra_schema_key = "extra"
     cache_dir = pathlib.Path(".probe_cache")
 
-    def __init__(self, schema_url, env_url, probes_url, mps_branch="master"):
+    def __init__(self, schema_url, env_url, probes_url, mps_branch="main"):
         self.schema_url = schema_url.format(branch=mps_branch)
         self.env_url = env_url.format(branch=mps_branch)
         self.probes_url = probes_url

--- a/tests/test_validate_bigquery.py
+++ b/tests/test_validate_bigquery.py
@@ -20,12 +20,12 @@ from mozilla_schema_generator.validate_bigquery import (
 def tmp_git(tmp_path):
     src = Path(__file__).parent / "resources" / "mozilla-pipeline-schemas"
     src_repo = Repo(src)
-    src_repo.git.checkout("master")
+    src_repo.git.checkout("main")
     src_repo.git.checkout("generated-schemas")
     Git(tmp_path).clone(src)
     path = tmp_path / "mozilla-pipeline-schemas"
     repo = Repo(path)
-    repo.git.checkout("master")
+    repo.git.checkout("main")
     repo.git.checkout("generated-schemas")
     # set config for ci
     repo.git.config("user.email", "test@test.com")
@@ -37,8 +37,8 @@ def test_tmp_git(tmp_git):
     repo = Repo(tmp_git)
     assert not repo.bare
     assert repo.head.ref.name == "generated-schemas"
-    repo.git.checkout("master")
-    assert repo.head.ref.name == "master"
+    repo.git.checkout("main")
+    assert repo.head.ref.name == "main"
 
 
 def test_compute_compact_columns():
@@ -116,10 +116,10 @@ def test_checkout_copy_schema_revisions_fails_and_reverts_state(tmp_path, tmp_gi
         )
     assert repo.head.ref.name == "generated-schemas"
     with pytest.raises(ValueError):
-        # no schemas found, since master branch does not have generated schemas
+        # no schemas found, since main branch does not have generated schemas
         # it's okay to have leftover files in the artifact directory
         head, base = checkout_copy_schemas_revisions(
-            "generated-schemas", "master", tmp_git, tmp_path
+            "generated-schemas", "main", tmp_git, tmp_path
         )
     assert repo.head.ref.name == "generated-schemas"
 


### PR DESCRIPTION
Both this repo and mozilla-pipeline-schemas now have `main` as the default branch name.