### PR TITLE
Bug 1703615 - Revert generated schema for rally-zero-one

### DIFF
--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -13,3 +13,8 @@ glean-js-tmp.*
 # Bug 1697602
 telemetry.account-ecosystem.*
 firefox-accounts.account-ecosystem.*
+
+# Bug 1703615, commit 26d53ee
+# This commit needs to be reverted due to the schema being incorrect.
+# https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/6172d894f37b4330aca87a1d8a5ff5acf85b4206
+rally-zero-one.*


### PR DESCRIPTION
[bug 1703615](https://bugzilla.mozilla.org/show_bug.cgi?id=1703615) and https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/671

The rally-zero-one schema was reverted due to it having the incorrect structure after discussion with @hamilton. The schema was generated and deployed to stage, which is fine since it hasn't been deployed to prod. CI prevents this from being removed without an explicit whitelist entry.

