### PR TITLE
Comment out rally-zero-one incompatibility

### DIFF
--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -17,4 +17,4 @@ firefox-accounts.account-ecosystem.*
 # Bug 1703615, commit 26d53ee
 # This commit needs to be reverted due to the schema being incorrect.
 # https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/6172d894f37b4330aca87a1d8a5ff5acf85b4206
-rally-zero-one.*
+# rally-zero-one.*


### PR DESCRIPTION
This is the followup to #191. Once the generated-schema has been overwritten, this can be merged in to place the normal validation rules against the namespace. 