### PR TITLE
Optimize Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+venv
+pip-log.txt
+pip-delete-this-directory.txt
+.tox
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+*.log
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,17 +31,20 @@ RUN pip install --upgrade pip
 
 WORKDIR ${HOME}
 
-ADD requirements requirements/
+# Recursively change ownership of the application folder to the user;
+# this takes a while, so we put this step before copying in code.
+RUN chown -R ${USER_ID}:${GROUP_ID} ${HOME}
+
+COPY --chown=${USER_ID}:${GROUP_ID} requirements requirements/
 RUN pip install -r requirements/requirements.txt
 RUN pip install -r requirements/test_requirements.txt
 
-ADD . ${HOME}/mozilla-schema-generator
+COPY --chown=${USER_ID}:${GROUP_ID} . ${HOME}/mozilla-schema-generator
 ENV PATH $PATH:${HOME}/mozilla-schema-generator/bin
 
 RUN pip install --no-dependencies -e ${HOME}/mozilla-schema-generator
 
-# Drop root and change ownership of the application folder to the user
-RUN chown -R ${USER_ID}:${GROUP_ID} ${HOME}
+# Drop root
 USER ${USER_ID}
 
 ENTRYPOINT ["schema_generator.sh"]


### PR DESCRIPTION
The recursive `chown` step takes over 30 seconds to execute, significantly
slowing down the development process when attempting to test changes with
`make build && make run`.

By putting this step earlier, changes to the `bin/` content no longer trigger
a rerun of the `chown` step, cutting build time to less than 10 seconds.