### PR TITLE
Update docker engine version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,12 @@ jobs:
 
   deploy:
     docker:
-      - image: docker:18.02.0-ce
+      - image: docker:20.10.2
     working_directory: ~/mozilla/mozilla-schema-generator
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.2
       - run: |
           printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BUILD_URL" > version.json
       - run: docker build -t app:build .

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+venv
+pip-log.txt
+pip-delete-this-directory.txt
+.tox
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+*.log
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,17 +31,20 @@ RUN pip install --upgrade pip
 
 WORKDIR ${HOME}
 
-ADD requirements requirements/
+# Recursively change ownership of the application folder to the user;
+# this takes a while, so we put this step before copying in code.
+RUN chown -R ${USER_ID}:${GROUP_ID} ${HOME}
+
+COPY --chown=${USER_ID}:${GROUP_ID} requirements requirements/
 RUN pip install -r requirements/requirements.txt
 RUN pip install -r requirements/test_requirements.txt
 
-ADD . ${HOME}/mozilla-schema-generator
+COPY --chown=${USER_ID}:${GROUP_ID} . ${HOME}/mozilla-schema-generator
 ENV PATH $PATH:${HOME}/mozilla-schema-generator/bin
 
 RUN pip install --no-dependencies -e ${HOME}/mozilla-schema-generator
 
-# Drop root and change ownership of the application folder to the user
-RUN chown -R ${USER_ID}:${GROUP_ID} ${HOME}
+# Drop root
 USER ${USER_ID}
 
 ENTRYPOINT ["schema_generator.sh"]


### PR DESCRIPTION
Bug fix for #193 

The current docker engine version being used doesn't interpret the variables passed in the chown part of COPY commands.

This configuration succeeded in https://app.circleci.com/pipelines/github/mozilla/mozilla-schema-generator/892/workflows/705b5c24-3408-4fdc-a294-f45091e6774c/jobs/1342