### PR TITLE
Bug 1706875 - Update metadata for generated rally glean.js apps

### DIFF
--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -18,3 +18,8 @@ firefox-accounts.account-ecosystem.*
 # This commit needs to be reverted due to the schema being incorrect.
 # https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/6172d894f37b4330aca87a1d8a5ff5acf85b4206
 # rally-zero-one.*
+
+# Bug 1706875
+# The rally-debug schema was commit using the structured metadata field instead
+# of the pioneer metadata schemas.
+rally-debug.*

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -161,7 +161,9 @@ class GleanPing(GenericPing):
             pipeline_meta = {
                 "bq_dataset_family": self.app_id.replace("-", "_"),
                 "bq_table": ping.replace("-", "_") + "_v1",
-                "bq_metadata_format": "structured",
+                "bq_metadata_format": (
+                    "pioneer" if self.app_id.startswith("rally") else "structured"
+                ),
             }
 
             retention_days = self.repo.get("retention_days")

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -157,17 +157,24 @@ class GleanPing(GenericPing):
             for matcher in matchers.values():
                 matcher.matcher["send_in_pings"]["contains"] = ping
             new_config = Config(ping, matchers=matchers)
-            retention_days = self.repo.get("retention_days", None)
 
             pipeline_meta = {
                 "bq_dataset_family": self.app_id.replace("-", "_"),
                 "bq_table": ping.replace("-", "_") + "_v1",
                 "bq_metadata_format": "structured",
             }
-            if retention_days is not None:
+
+            retention_days = self.repo.get("retention_days")
+            if retention_days:
                 expiration = pipeline_meta.get("expiration_policy", {})
                 expiration["delete_after_days"] = int(retention_days)
                 pipeline_meta["expiration_policy"] = expiration
+
+            use_jwk = self.repo.get("encryption", {}).get("use_jwk")
+            if use_jwk:
+                pipeline_meta["jwe_mappings"] = [
+                    {"source_field_path": "/payload", "decrypted_field_path": ""}
+                ]
 
             defaults = {"mozPipelineMetadata": pipeline_meta}
 

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -97,3 +97,22 @@ class TestGleanPing(object):
                 schema["mozPipelineMetadata"]["expiration_policy"]["delete_after_days"]
                 == 90
             )
+
+    def test_encryption_exists(self, config):
+        glean = glean_ping.GleanPing(
+            {
+                "name": "glean-core",
+                "app_id": "org-mozilla-glean",
+                "encryption": {"use_jwk": True},
+            }
+        )
+        schemas = glean.generate_schema(config, split=False, generic_schema=True)
+
+        final_schemas = {k: schemas[k][0].schema for k in schemas}
+        for name, schema in final_schemas.items():
+            jwe_mappings = schema["mozPipelineMetadata"]["jwe_mappings"]
+            assert len(jwe_mappings) == 1
+            assert set(jwe_mappings[0].keys()) == {
+                "source_field_path",
+                "decrypted_field_path",
+            }

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -116,3 +116,18 @@ class TestGleanPing(object):
                 "source_field_path",
                 "decrypted_field_path",
             }
+
+    def test_rally_metadata_format(self, config):
+        glean = glean_ping.GleanPing(
+            {
+                "name": "rally-debug",
+                "app_id": "rally_debug",
+                "encryption": {"use_jwk": True},
+            }
+        )
+        schemas = glean.generate_schema(config, split=False, generic_schema=True)
+
+        final_schemas = {k: schemas[k][0].schema for k in schemas}
+        for name, schema in final_schemas.items():
+            metadata_format = schema["mozPipelineMetadata"]["bq_metadata_format"]
+            assert metadata_format == "pioneer"


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1706875)

See https://github.com/mozilla/gcp-ingestion/pull/1617 for decoder changes and https://github.com/mozilla/probe-scraper/pull/308/files for changes in the probe scraper.

I miscalculated and thought that jwe_mappings were the only piece of metadata that needed to be added. The `bq_metadata_format` needs to change too. The wrong metadata was committed into generated-schemas and needs to be overwritten.