### PR TITLE
Add autogenerated documentation via pdoc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ workflows:
             - docs-build
           filters:
             branches:
-              only: docs
+              only: main
 
       - deploy:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,24 @@ jobs:
             make lint
             make test
             make coverage
+
+  docs-build:
+    docker: *docker
+    steps:
+      - checkout
+      - run:
+          name: "Pull Submodules"
+          command: |
+            git submodule init
+            git submodule update --remote
       - run:
           name: Build docs
           command: |
+            python3 -m virtualenv venv
             . venv/bin/activate
+            make install-requirements
             pip install pdoc
-            pdoc -o _html generator
+            pdoc -o _html mozilla_pipeline_schemas
       - persist_to_workspace:
           root: docs/_build
           paths: _html
@@ -97,9 +109,15 @@ workflows:
             tags:
               only: /.*/
 
+      - docs-build:
+          filters:
+            tags:
+              only: /.*/
+
       - docs-deploy:
           requires:
             - test
+            - docs-build
           filters:
             branches:
               only: docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             pip install pdoc
             pdoc -o _html mozilla_schema_generator
       - persist_to_workspace:
-          root: docs/_build
+          root: docs
           paths: _html
 
   docs-deploy:
@@ -57,7 +57,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: docs/_build
+          at: docs
       - run:
           name: Install and configure dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,9 @@ jobs:
             . venv/bin/activate
             make install-requirements
             pip install pdoc
-            pdoc -o _html mozilla_schema_generator
+            pdoc -o /tmp/_html mozilla_schema_generator
       - persist_to_workspace:
-          root: docs
+          root: /tmp
           paths: _html
 
   docs-deploy:
@@ -57,7 +57,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: docs
+          at: /tmp
       - run:
           name: Install and configure dependencies
           command: |
@@ -66,7 +66,7 @@ jobs:
             git config user.name "ci-build-docs"
       - run:
           name: Deploy docs to gh-pages branch
-          command: gh-pages --dist docs/_build
+          command: gh-pages --dist _html
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,9 @@ jobs:
             npm install -g --silent gh-pages@3.0.0
             git config user.email "ci-build-docs@mozilla.com"
             git config user.name "ci-build-docs"
+      - add_ssh_keys:
+          fingerprints:
+            - "2d:8d:b3:4c:6d:56:0d:9c:b1:8d:99:8c:b0:de:4b:56"
       - run:
           name: Deploy docs to gh-pages branch
           command: gh-pages --message "[skip ci] updates" --dist /tmp/_html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,11 @@ jobs:
             make test
             make coverage
       - run:
-          name: Install pdocs
-          command: pip install pdoc
-      - run:
           name: Build docs
-          command: pdoc -o _html generator
+          command: |
+            . venv/bin/activate
+            pip install pdoc
+            pdoc -o _html generator
       - persist_to_workspace:
           root: docs/_build
           paths: _html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,12 +66,12 @@ jobs:
       - run:
           name: Install and configure dependencies
           command: |
-            npm install -g --silent gh-pages
+            npm install -g --silent gh-pages@3.0.0
             git config user.email "ci-build-docs@mozilla.com"
             git config user.name "ci-build-docs"
       - run:
           name: Deploy docs to gh-pages branch
-          command: gh-pages --dest /tmp/_html
+          command: gh-pages --message "[skip ci] updates" --dist /tmp/_html
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,11 @@ jobs:
       - image: node:14
     steps:
       - checkout
+      - run:
+          name: "Pull Submodules"
+          command: |
+            git submodule init
+            git submodule update --remote
       - attach_workspace:
           at: /tmp
       - run:
@@ -66,7 +71,7 @@ jobs:
             git config user.name "ci-build-docs"
       - run:
           name: Deploy docs to gh-pages branch
-          command: gh-pages --dist /tmp/_html
+          command: gh-pages --dest /tmp/_html
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             . venv/bin/activate
             make install-requirements
             pip install pdoc
-            pdoc -o _html mozilla_pipeline_schemas
+            pdoc -o _html mozilla_schema_generator
       - persist_to_workspace:
           root: docs/_build
           paths: _html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
             git config user.name "ci-build-docs"
       - run:
           name: Deploy docs to gh-pages branch
-          command: gh-pages --dist _html
+          command: gh-pages --dist /tmp/_html
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ version: 2
 
 jobs:
   test:
-    docker: # run the steps with Docker
+    docker: &docker
       - image: circleci/python:3.7.2
     steps:
       - checkout
@@ -29,6 +29,32 @@ jobs:
             make lint
             make test
             make coverage
+      - run:
+          name:
+            pip install pdoc
+      - run:
+          name: Build docs
+          command: pdoc -o _html generator
+      - persist_to_workspace:
+          root: docs/_build
+          paths: _html
+
+  docs-deploy:
+    docker:
+      - image: node:14
+    steps:
+      - checkout
+      - attach_workspace:
+          at: docs/_build
+      - run:
+          name: Install and configure dependencies
+          command: |
+            npm install -g --silent gh-pages
+            git config user.email "ci-build-docs@mozilla.com"
+            git config user.name "ci-build-docs"
+      - run:
+          name: Deploy docs to gh-pages branch
+          command: gh-pages --dist docs/_build
 
   deploy:
     docker:
@@ -70,6 +96,13 @@ workflows:
           filters:
             tags:
               only: /.*/
+
+      - docs-deploy:
+          requires:
+            - test
+          filters:
+            branches:
+              only: docs
 
       - deploy:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             . venv/bin/activate
             make install-requirements
             pip install pdoc
-            pdoc -o /tmp/_html mozilla_schema_generator
+            pdoc -o /tmp/_html ./mozilla_schema_generator
       - persist_to_workspace:
           root: /tmp
           paths: _html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
             make test
             make coverage
       - run:
-          name:
-            pip install pdoc
+          name: Install pdocs
+          command: pip install pdoc
       - run:
           name: Build docs
           command: pdoc -o _html generator

--- a/mozilla_schema_generator/__init__.py
+++ b/mozilla_schema_generator/__init__.py
@@ -3,6 +3,11 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Generate schemas for mozilla-pipeline-schemas.
+
+.. include:: ../README.md
+"""
+__docformat__ = "restructuredtext"
 
 __author__ = "Frank Bertsch"
 __email__ = "frank@mozilla.com"


### PR DESCRIPTION
I've configured autogenerated api docs with pdoc following a guide. This should be useful for quickly finding out what the public interface of the classes here are.

* https://pdoc.dev/
* https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/
* https://mozilla.github.io/mozilla-schema-generator/