### PR TITLE
Use user's home directory to store probe cache

### DIFF
--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -23,7 +23,7 @@ class GenericPing(object):
     default_encoding = "utf-8"
     default_max_size = 11000  # https://bugzilla.mozilla.org/show_bug.cgi?id=1688633
     extra_schema_key = "extra"
-    cache_dir = pathlib.Path(".probe_cache")
+    cache_dir = pathlib.Path.home() / ".msg_probe_cache"
 
     def __init__(self, schema_url, env_url, probes_url, mps_branch="main"):
         self.schema_url = schema_url.format(branch=mps_branch)


### PR DESCRIPTION
The current working directory may not be readable by the user in all
cases (e.g. inside a docker container).

May help with: https://github.com/mozilla/bigquery-etl/issues/2214
