### PR TITLE
Fix race with creating cache dir

### DIFF
--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -177,8 +177,7 @@ class GenericPing(object):
 
     @staticmethod
     def _add_to_cache(url: str, val: str):
-        if not GenericPing.cache_dir.exists():
-            GenericPing.cache_dir.mkdir(parents=True)
+        GenericPing.cache_dir.mkdir(parents=True, exist_ok=True)
 
         (GenericPing.cache_dir / GenericPing._slugify(url)).write_text(val)
 


### PR DESCRIPTION
When running multiple concurrent threads or processes calling
mozilla-schema-generator, it is possible for the call to create
a directory for our cache to fail. Instead of checking-and-then-creating,
just create and then ignore if the directory already exists.
