### PR TITLE
Open cache file for writing if it does not already exist

### DIFF
--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -184,7 +184,8 @@ class GenericPing(object):
         GenericPing.cache_dir.mkdir(parents=True, exist_ok=True)
 
         cache_file = GenericPing.cache_dir / GenericPing._slugify(url)
-        # protect against multiple writers to the cache: https://github.com/mozilla/mozilla-schema-generator/pull/210
+        # protect against multiple writers to the cache:
+        # https://github.com/mozilla/mozilla-schema-generator/pull/210
         try:
             with open(cache_file, "x") as f:
                 f.write(val)

--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -183,7 +183,12 @@ class GenericPing(object):
     def _add_to_cache(url: str, val: str):
         GenericPing.cache_dir.mkdir(parents=True, exist_ok=True)
 
-        (GenericPing.cache_dir / GenericPing._slugify(url)).write_text(val)
+        cache_file = GenericPing.cache_dir / GenericPing._slugify(url)
+        try:
+            with open(cache_file, "x") as f:
+                f.write(val)
+        except FileExistsError:
+            pass
 
     @staticmethod
     def _retrieve_from_cache(url: str) -> str:

--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -184,6 +184,7 @@ class GenericPing(object):
         GenericPing.cache_dir.mkdir(parents=True, exist_ok=True)
 
         cache_file = GenericPing.cache_dir / GenericPing._slugify(url)
+        # protect against multiple writers to the cache: https://github.com/mozilla/mozilla-schema-generator/pull/210
         try:
             with open(cache_file, "x") as f:
                 f.write(val)


### PR DESCRIPTION
https://github.com/mozilla/bigquery-etl/issues/2300
https://mozilla-hub.atlassian.net/browse/DSRE-172

Based on my investigation this is not an issue with probeinfo.telemetry.mozilla.org serving requests but the caching mechanism in mozilla-schema-generator. Specifically we use multiprocessing to parallelize runs within bigquery-etl and there is race condition to populate cache:

- cache is empty
- process A and B try to populate the same cache at the same time, process A succeeds
- process C sees a cache file presents and tries to read the cache file
- process B is ready to write cache and truncates the file and begins to write
- process C reads an empty cache file and throws a JSON decode error 
- process B succeeds in writing to cache

 I am not sure how much we use this cache, but I figure this is a simple enough solution to not clobber existing cache. 

