### PR TITLE
Bug 1737656 Rename metrics.url to metrics.url2, etc.

### DIFF
--- a/mozilla_schema_generator/configs/glean.yaml
+++ b/mozilla_schema_generator/configs/glean.yaml
@@ -95,24 +95,53 @@ metrics:
       send_in_pings:
         not:
           - glean_ping_info
-      type: labeled_rate
+      type: not_a_real_type
+
+  # Metric types affected by bug 1737656;
+  # The jwe, labeled_rate, url, and text types were deployed to BigQuery tables
+  # with incorrect structure, so we've had to rename these types in BQ tables;
+  # we use a "2" suffix for the fields in BQ.
   jwe:
     match:
       bug_1737656_affected: true
       send_in_pings:
         not:
           - glean_ping_info
-      type: jwe
+      type: not_a_real_type
+  labeled_rate2:
+    match:
+      send_in_pings:
+        not:
+          - glean_ping_info
+      type: labeled_rate
   text:
     match:
       bug_1737656_affected: true
       send_in_pings:
         not:
           - glean_ping_info
-      type: text
+      type: not_a_real_type
   url:
     match:
       bug_1737656_affected: true
+      send_in_pings:
+        not:
+          - glean_ping_info
+      type: not_a_real_type
+  jwe2:
+    match:
+      send_in_pings:
+        not:
+          - glean_ping_info
+      type: jwe
+  text2:
+    match:
+      send_in_pings:
+        not:
+          - glean_ping_info
+      type: text
+  url2:
+    match:
       send_in_pings:
         not:
           - glean_ping_info

--- a/mozilla_schema_generator/configs/glean.yaml
+++ b/mozilla_schema_generator/configs/glean.yaml
@@ -90,7 +90,7 @@ metrics:
           - glean_ping_info
       type: labeled_string
 
-  # Metric types affected by bug 1737656;
+  # Metric types affected by https://bugzilla.mozilla.org/show_bug.cgi?id=1737656
   # The jwe, labeled_rate, url, and text types were deployed to BigQuery tables
   # with incorrect structure, so we've had to rename these types in BQ tables;
   # we use a "2" suffix for the fields in BQ.

--- a/mozilla_schema_generator/configs/glean.yaml
+++ b/mozilla_schema_generator/configs/glean.yaml
@@ -89,19 +89,25 @@ metrics:
         not:
           - glean_ping_info
       type: labeled_string
-  labeled_rate:
-    match:
-      bug_1737656_affected: true
-      send_in_pings:
-        not:
-          - glean_ping_info
-      type: not_a_real_type
 
   # Metric types affected by bug 1737656;
   # The jwe, labeled_rate, url, and text types were deployed to BigQuery tables
   # with incorrect structure, so we've had to rename these types in BQ tables;
   # we use a "2" suffix for the fields in BQ.
   jwe:
+    match:
+      bug_1737656_affected: true
+      send_in_pings:
+        not:
+          - glean_ping_info
+      type: not_a_real_type
+  jwe2:
+    match:
+      send_in_pings:
+        not:
+          - glean_ping_info
+      type: jwe
+  labeled_rate:
     match:
       bug_1737656_affected: true
       send_in_pings:
@@ -121,6 +127,12 @@ metrics:
         not:
           - glean_ping_info
       type: not_a_real_type
+  text2:
+    match:
+      send_in_pings:
+        not:
+          - glean_ping_info
+      type: text
   url:
     match:
       bug_1737656_affected: true
@@ -128,18 +140,6 @@ metrics:
         not:
           - glean_ping_info
       type: not_a_real_type
-  jwe2:
-    match:
-      send_in_pings:
-        not:
-          - glean_ping_info
-      type: jwe
-  text2:
-    match:
-      send_in_pings:
-        not:
-          - glean_ping_info
-      type: text
   url2:
     match:
       send_in_pings:

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -57,6 +57,20 @@ class GleanPing(GenericPing):
             **kwargs,
         )
 
+    def get_schema(self) -> Schema:
+        schema = super().get_schema()
+
+        # We need to inject placeholders for the url2, text2, etc. types as part
+        # of mitigation for https://bugzilla.mozilla.org/show_bug.cgi?id=1737656
+        for metric_name in ["labeled_rate", "jwe", "url", "text"]:
+            metric1 = schema.get(("properties", "metrics", "properties", metric_name)).copy()
+            metric1 = schema.set_schema_elem(
+                ("properties", "metrics", "properties", metric_name + "2"),
+                metric1,
+            )
+
+        return schema
+
     def get_dependencies(self):
         # Get all of the library dependencies for the application that
         # are also known about in the repositories file.

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -57,8 +57,16 @@ class GleanPing(GenericPing):
             **kwargs,
         )
 
-    def get_schema(self) -> Schema:
+    def get_schema(self, generic_schema=False) -> Schema:
+        """
+        Fetch schema via URL.
+
+        Unless *generic_schema* is set to true, this function makes some modifications
+        to allow some workarounds for proper injection of metrics.
+        """
         schema = super().get_schema()
+        if generic_schema:
+            return schema
 
         # We need to inject placeholders for the url2, text2, etc. types as part
         # of mitigation for https://bugzilla.mozilla.org/show_bug.cgi?id=1737656
@@ -227,7 +235,7 @@ class GleanPing(GenericPing):
             defaults = {"mozPipelineMetadata": pipeline_meta}
 
             if generic_schema:  # Use the generic glean ping schema
-                schema = self.get_schema()
+                schema = self.get_schema(generic_schema=True)
                 schema.schema.update(defaults)
                 schemas[new_config.name] = [schema]
             else:

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -215,10 +215,11 @@ class GleanPing(GenericPing):
             # Four newly introduced metric types were incorrectly deployed
             # as repeated key/value structs in all Glean ping tables existing prior
             # to November 2021. We maintain the incorrect fields for existing tables
-            # by disabling the associated matchers, but all new Glean pings will have
-            # the matchers enabled, meaning these jwe, labeled_rate, text, and url types
-            # will only show up in the schema if the ping is defined to contain metrics
-            # of those types.
+            # by disabling the associated matchers.
+            # Note that each of these types now has a "2" matcher ("text2", "url2", etc.)
+            # defined that will allow metrics of these types to be injected into proper
+            # structs. The gcp-ingestion repository includes logic to rewrite these
+            # metrics under the "2" names.
             # See https://bugzilla.mozilla.org/show_bug.cgi?id=1737656
             bq_identifier = "{bq_dataset_family}.{bq_table}".format(**pipeline_meta)
             if bq_identifier in self.bug_1737656_affected_tables:

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -63,7 +63,9 @@ class GleanPing(GenericPing):
         # We need to inject placeholders for the url2, text2, etc. types as part
         # of mitigation for https://bugzilla.mozilla.org/show_bug.cgi?id=1737656
         for metric_name in ["labeled_rate", "jwe", "url", "text"]:
-            metric1 = schema.get(("properties", "metrics", "properties", metric_name)).copy()
+            metric1 = schema.get(
+                ("properties", "metrics", "properties", metric_name)
+            ).copy()
             metric1 = schema.set_schema_elem(
                 ("properties", "metrics", "properties", metric_name + "2"),
                 metric1,

--- a/mozilla_schema_generator/schema.py
+++ b/mozilla_schema_generator/schema.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import copy
 from json import JSONEncoder
-from typing import Any, Tuple
+from typing import Any, Iterable
 
 from .utils import _get
 
@@ -34,7 +34,7 @@ class Schema(object):
     def __init__(self, schema: dict):
         self.schema = schema
 
-    def set_schema_elem(self, key: Tuple[str], elem: Any, *, propagate=True) -> dict:
+    def set_schema_elem(self, key: Iterable[str], elem: Any, *, propagate=True) -> dict:
         """
         @param key: The key set
         @param elem: The value to set the key to
@@ -56,7 +56,7 @@ class Schema(object):
 
         new_elem[key[-1]] = elem
 
-    def get(self, key: Tuple[str]) -> Any:
+    def get(self, key: Iterable[str]) -> Any:
         return _get(self.schema, key)
 
     def get_size(self) -> int:
@@ -65,14 +65,14 @@ class Schema(object):
     def clone(self) -> Schema:
         return Schema(copy.deepcopy(self.schema))
 
-    def _delete_key(self, key: Tuple[str]):
+    def _delete_key(self, key: Iterable[str]):
         try:
             elem = _get(self.schema, key[:-1])
             del elem[key[-1]]
         except KeyError:
             return
 
-    def delete_group_from_schema(self, key: Tuple[str], *, propagate=True):
+    def delete_group_from_schema(self, key: Iterable[str], *, propagate=True):
         """
         @param key: The key to remove
         @param propagate: If True, then removes any parents of the deleted key
@@ -98,7 +98,7 @@ class Schema(object):
                 except KeyError:
                     break
 
-    def property_exists(self, key: Tuple[str]) -> bool:
+    def property_exists(self, key: Iterable[str]) -> bool:
         """
         @param key: The key to check for existence
         """

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -107,7 +107,7 @@ class TestGleanPing(object):
 
         final_schemas = {k: schemas[k][0].schema for k in schemas}
         for name, schema in final_schemas.items():
-            generic_schema = glean.get_schema().schema
+            generic_schema = glean.get_schema(generic_schema=True).schema
             generic_schema["mozPipelineMetadata"] = {
                 "bq_dataset_family": "org_mozilla_glean",
                 "bq_metadata_format": "structured",
@@ -217,7 +217,8 @@ class TestGleanPing(object):
 
         final_schemas = {k: schemas[k][0].schema for k in schemas}
         schema = final_schemas.get("metrics")
+        assert "url" not in schema["properties"]["metrics"]["properties"].keys()
+        assert "url2" in schema["properties"]["metrics"]["properties"].keys()
         assert list(
             (schema["properties"]["metrics"]["properties"]["url2"]["properties"].keys())
         ) == ["my_url"]
-        assert "url" not in schema["properties"]["metrics"]["properties"].keys()


### PR DESCRIPTION
This is one piece of the design discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1737656#c21

Relies on a coordinated pipeline change being developed in https://github.com/mozilla/gcp-ingestion/pull/1881

Although it should be possible to deploy these in any order without breaking the pipeline.