### PR TITLE
DSRE-582 Reduce retention and granularity for Glean topsites

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -208,6 +208,19 @@ class GleanPing(GenericPing):
                     {"source_field_path": "/payload", "decrypted_field_path": ""}
                 ]
 
+            # DSRE-582 Reduce retention and granularity for contextual services pings;
+            # we set the same defaults as for desktop contextual-services pings per
+            # https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/main
+            #   /templates/contextual-services/defaults.schema.json
+            if ping.startswith("topsites") or ping.startswith("quicksuggest"):
+                pipeline_meta["submission_timestamp_granularity"] = "seconds"
+                expiration = pipeline_meta.get("expiration_policy", {})
+                expiration["delete_after_days"] = 30
+                pipeline_meta["expiration_policy"] = expiration
+                override_attributes = pipeline_meta.get("override_attributes", {})
+                override_attributes["geo_city"] = None
+                pipeline_meta["override_attributes"] = override_attributes
+
             matchers = {
                 loc: m.clone(new_table_group=ping) for loc, m in config.matchers.items()
             }


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/DSRE-582

The [diff on the `test-generated-schemas` branch](https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/5c92c720743bf081ebd76f616cba90228f4965d7) demonstrates the effects of this change.

We will need to handle ACLs on these tables separately.