### PR TITLE
upgraded version of click package, older version was causing black to fail

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-click==7.0
+click==8.0.1
 pyyaml==4.2b1
 requests==2.21.0
 wheel>=0.22


### PR DESCRIPTION
upgraded version of click package, older version was causing black to fail.

Error msg:
![image](https://user-images.githubusercontent.com/42538694/160593016-f98fd0a1-c313-4a9b-a823-380b9f0522e8.png)
