### PR TITLE
skipping rally_debug events validation for metrics_text field

### DIFF
--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -185,7 +185,14 @@ class TestGleanPing(object):
         final_schemas = {k: schemas[k][0].schema for k in schemas}
         for name, schema in final_schemas.items():
             # Only this static list of pings should have the incorrect schema for text
-            if name not in ["deletion-request", "demographics", "enrollment", "study-enrollment", "study-unenrollment", "uninstall-deletion"]:
+            if name not in [
+                "deletion-request",
+                "demographics",
+                "enrollment",
+                "study-enrollment",
+                "study-unenrollment",
+                "uninstall-deletion",
+            ]:
                 continue
 
             metrics_text = schema["properties"]["metrics"]["properties"]["text"]

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -184,8 +184,8 @@ class TestGleanPing(object):
 
         final_schemas = {k: schemas[k][0].schema for k in schemas}
         for name, schema in final_schemas.items():
-            # text field for rally_debug events not expected
-            if schema["mozPipelineMetadata"]["bq_dataset_family"] == "rally_debug":
+            # Only this static list of pings should have the incorrect schema for text
+            if name not in ["deletion-request", "demographics", "enrollment", "study-enrollment", "study-unenrollment", "uninstall-deletion"]:
                 continue
 
             metrics_text = schema["properties"]["metrics"]["properties"]["text"]

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -184,7 +184,12 @@ class TestGleanPing(object):
 
         final_schemas = {k: schemas[k][0].schema for k in schemas}
         for name, schema in final_schemas.items():
+            # text field for rally_debug events not expected
+            if schema["mozPipelineMetadata"]["bq_dataset_family"] == "rally_debug":
+                continue
+
             metrics_text = schema["properties"]["metrics"]["properties"]["text"]
+
             assert metrics_text is not None
             assert type(metrics_text.get("additionalProperties")) is dict
 


### PR DESCRIPTION
skipping rally_debug events validation for metrics_text field

This is because for this event type metrics["properties"]["text"] is not required.