### PR TITLE
Comment out rally-citp-search-engine-usage incompatibility

### DIFF
--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -27,4 +27,4 @@ firefox-accounts.account-ecosystem.*
 # Bug 1762997
 # Old commits with broken schemas were fetched and half-deployed.
 # This is a companion to mozilla/probe-scraper#419
-rally-citp-search-engine-usage.*
+# rally-citp-search-engine-usage.*


### PR DESCRIPTION
We want to prevent schema-incompatible changes going forward.