### PR TITLE
Only check for missing bq schemas in schemas directory

### DIFF
--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -110,7 +110,7 @@ function _create_changelog() {
 
 function _check_all_schemas_have_bq() {
     MISSING_BQ_SCHEMAS="$(
-      find . -type f -name "*.schema.json" |
+      find ./schemas -type f -name "*.schema.json" |
       sed 's/schema.json/bq/' |
       grep -vf "$DISALLOWLIST" |
       # echo files that don't exist


### PR DESCRIPTION
fixes error from attempt 4 in https://workflow.telemetry.mozilla.org/log?dag_id=probe_scraper&task_id=mozilla_schema_generator&execution_date=2023-01-16T00%3A00%3A00%2B00%3A00