### PR TITLE
[Bug 1816136] Add mozillavpn to incompatibility list

### DIFF
--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -40,7 +40,8 @@ firefox-accounts.account-ecosystem.*
 # rally-attention-stream.*
 
 # Bug 1804256
-# Delete mozillavpn.metrics and mozillavpn.baseline after reverting changes to unify VPN apps
-# This is a companion to https://github.com/mozilla/probe-scraper/pull/550
+# Delete mozillavpn.metrics and mozillavpn.baseline after fixing typo in https://github.com/mozilla/probe-scraper/pull/553
+# mozillavpn was treated as Glean.js app after typo got fixed, which resulted in these 
+# ping schemas being removed (since they don't exist for Glean.js)
 mozillavpn.metrics.*
 mozillavpn.baseline.*

--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -42,5 +42,5 @@ firefox-accounts.account-ecosystem.*
 # Bug 1804256
 # Delete mozillavpn.metrics and mozillavpn.baseline after reverting changes to unify VPN apps
 # This is a companion to https://github.com/mozilla/probe-scraper/pull/550
-# mozillavpn.metrics.*
-# mozillavpn.baseline.*
+mozillavpn.metrics.*
+mozillavpn.baseline.*


### PR DESCRIPTION
Related to https://github.com/mozilla/probe-scraper/pull/553

Glean.js doesn't have `baseline` and `metrics` tables, but since there was a bug mozillavpn wasn't considered as Glean.js app so these schemas got initially created. With the fix they get removed again.