### PR TITLE
Pin debian buster (lts) for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7-buster
 MAINTAINER Frank Bertsch <frank@mozilla.com>
 
 # Guidelines here: https://github.com/mozilla-services/Dockerflow/blob/main/docs/building-container.md


### PR DESCRIPTION
because update to debian bookworm is breaking CI