### PR TITLE
Support moving data out of remainder pings

### DIFF
--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -35,6 +35,7 @@ def test_subset(tmp_path: Path):
                         "document_type": "subset",
                         "document_version": "1",
                         "pattern": ".*int",
+                        "extra_pattern": ".*int64",
                     },
                 ],
                 "remainder": {
@@ -50,6 +51,7 @@ def test_subset(tmp_path: Path):
                 "type": "object",
                 "properties": {
                     "int": {"type": "integer"},
+                    "int64": {"type": "integer"},
                     "string": {"type": "string"},
                 },
                 "required": [],
@@ -72,7 +74,10 @@ def test_subset(tmp_path: Path):
             "client_id": {"type": "string"},
             "payload": {
                 "type": "object",
-                "properties": {"string": {"type": "string"}},
+                "properties": {
+                    "int64": {"type": "integer"},
+                    "string": {"type": "string"},
+                },
                 "required": [],
             },
             "test_string": {"type": "string"},
@@ -92,7 +97,10 @@ def test_subset(tmp_path: Path):
             "client_id": {"type": "string"},
             "payload": {
                 "type": "object",
-                "properties": {"int": {"type": "integer"}},
+                "properties": {
+                    "int": {"type": "integer"},
+                    "int64": {"type": "integer"},
+                },
             },
             "test_int": {"type": "integer"},
         },


### PR DESCRIPTION
blocks https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/783

context: I missed some histograms when splitting out use counter pings, and now they need to be moved, but their schema needs to be preserved in the remainder pings because schemas are not allowed to delete fields.