### PR TITLE
Remove unused `ignore_pings` list

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -34,13 +34,6 @@ class GleanPing(GenericPing):
     )
 
     default_dependencies = ["glean-core"]
-    ignore_pings = {
-        "all-pings",
-        "all_pings",
-        "default",
-        "glean_ping_info",
-        "glean_client_info",
-    }
 
     with open(BUG_1737656_TXT, "r") as f:
         bug_1737656_affected_tables = [


### PR DESCRIPTION
The last use was removed in ce8c2061f75ec49e6acdd58cec4d44a8c7937148