### PR TITLE
[DENG-3022] Add support for minimum glean ping schema selection

### DIFF
--- a/mozilla_schema_generator/generic_ping.py
+++ b/mozilla_schema_generator/generic_ping.py
@@ -28,8 +28,9 @@ class GenericPing(object):
     cache_dir = pathlib.Path(os.environ.get("MSG_PROBE_CACHE_DIR", ".probe_cache"))
 
     def __init__(self, schema_url, env_url, probes_url, mps_branch="main"):
-        self.schema_url = schema_url.format(branch=mps_branch)
-        self.env_url = env_url.format(branch=mps_branch)
+        self.branch_name = mps_branch
+        self.schema_url = schema_url.format(branch=self.branch_name)
+        self.env_url = env_url.format(branch=self.branch_name)
         self.probes_url = probes_url
 
     def get_schema(self) -> Schema:

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -300,7 +300,7 @@ class GleanPing(GenericPing):
 
     def _include_info_sections(self, ping_data) -> bool:
         # Default to true if not specified.
-        if "history" not in ping_data:
+        if "history" not in ping_data or len(ping_data["history"]) == 0:
             return True
         latest_ping_data = ping_data["history"][-1]
         return (
@@ -350,13 +350,13 @@ class GleanPing(GenericPing):
 
             defaults = {"mozPipelineMetadata": pipeline_meta}
 
+            # Adjust the schema path if the ping does not require info sections
+            self.set_schema_url(pipeline_meta)
             if generic_schema:  # Use the generic glean ping schema
                 schema = self.get_schema(generic_schema=True)
                 schema.schema.update(defaults)
                 schemas[new_config.name] = schema
             else:
-                # Adjust the schema path if the ping does not require info sections
-                self.set_schema_url(pipeline_meta)
                 generated = super().generate_schema(new_config)
                 for schema in generated.values():
                     # We want to override each individual key with assembled defaults,

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -30,6 +30,7 @@ MINIMUM_SCHEMA_URL = (
     "/{branch}/schemas/glean/glean/glean-min.1.schema.json"
 )
 
+
 class GleanPing(GenericPing):
     probes_url_template = GenericPing.probe_info_base_url + "/glean/{}/metrics"
     ping_url_template = GenericPing.probe_info_base_url + "/glean/{}/pings"
@@ -302,8 +303,10 @@ class GleanPing(GenericPing):
         if "history" not in ping_data:
             return True
         latest_ping_data = ping_data["history"][-1]
-        return ("include_info_sections" not in latest_ping_data
-                or latest_ping_data["include_info_sections"])
+        return (
+            "include_info_sections" not in latest_ping_data
+            or latest_ping_data["include_info_sections"]
+        )
 
     def set_schema_url(self, metadata):
         """

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -619,7 +619,9 @@ class TestGleanPing(object):
         ]
 
         # TODO remove the temp branch name when the min schema pr lands
-        glean = GleanPingNoInfoSection({"name": "app1", "app_id": "app1"}, mps_branch="wstuckey/glean-min")
+        glean = GleanPingNoInfoSection(
+            {"name": "app1", "app_id": "app1"}, mps_branch="wstuckey/glean-min"
+        )
         schemas = glean.generate_schema(config, generic_schema=True)
         final_schemas = {k: schemas[k].schema for k in schemas}
 

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -96,6 +96,7 @@ class GleanPingWithExpirationPolicy(GleanPingStub):
             "delete_after_days": 12,
             "collect_through_date": "2022-06-10",
         },
+        "include_info_sections": True,
     }
 
 
@@ -104,6 +105,7 @@ class GleanPingWithEncryption(GleanPingStub):
         "bq_dataset_family": "app1",
         "bq_metadata_format": "structured",
         "bq_table": "ping1_v1",
+        "include_info_sections": True,
         "jwe_mappings": [
             {
                 "decrypted_field_path": "",
@@ -118,6 +120,7 @@ class GleanPingNoMetadata(GleanPingStub):
         "bq_dataset_family": "app1",
         "bq_metadata_format": "structured",
         "bq_table": "ping1_v1",
+        "include_info_sections": True,
     }
 
 
@@ -126,6 +129,7 @@ class GleanPingWithOverrideAttributes(GleanPingStub):
         "bq_dataset_family": "app1",
         "bq_metadata_format": "structured",
         "bq_table": "ping1_v1",
+        "include_info_sections": True,
         "override_attributes": [{"name": "geo_city", "value": None}],
     }
 
@@ -135,6 +139,7 @@ class GleanPingWithGranularity(GleanPingStub):
         "bq_dataset_family": "app1",
         "bq_metadata_format": "structured",
         "bq_table": "ping1_v1",
+        "include_info_sections": True,
         "submission_timestamp_granularity": "seconds",
     }
 
@@ -145,6 +150,7 @@ class GleanPingWithMultiplePings(GleanPingStub):
         "bq_metadata_format": "structured",
         "bq_table": "ping1_v1",
         "expiration_policy": {"delete_after_days": 30},
+        "include_info_sections": True,
         "override_attributes": [{"name": "geo_city", "value": None}],
         "submission_timestamp_granularity": "seconds",
     }
@@ -154,6 +160,7 @@ class GleanPingWithMultiplePings(GleanPingStub):
         "bq_metadata_format": "structured",
         "bq_table": "ping2_v1",
         "expiration_policy": {"delete_after_days": 45},
+        "include_info_sections": True,
         "submission_timestamp_granularity": "millis",
     }
 
@@ -318,6 +325,7 @@ class TestGleanPing(object):
                 "bq_dataset_family": "glean_core",
                 "bq_metadata_format": "structured",
                 "bq_table": name.replace("-", "_") + "_v1",
+                "include_info_sections": True,
             }
             print_and_test(generic_schema, schema)
 
@@ -363,7 +371,7 @@ class TestGleanPing(object):
                 )
             if name == "dependency_ping":
                 # Need to do individual comparison due to update of value based on app_id
-                assert len(schema["mozPipelineMetadata"]) == 4
+                assert len(schema["mozPipelineMetadata"]) == 5
                 assert schema["mozPipelineMetadata"]["bq_dataset_family"] == "app1"
                 assert (
                     schema["mozPipelineMetadata"]["bq_metadata_format"] == "structured"
@@ -415,7 +423,7 @@ class TestGleanPing(object):
                 )
             if name == "dependency_ping":
                 # Need to do individual comparison due to update of value based on app_id
-                assert len(schema["mozPipelineMetadata"]) == 4
+                assert len(schema["mozPipelineMetadata"]) == 5
                 assert schema["mozPipelineMetadata"]["bq_dataset_family"] == "app1"
                 assert (
                     schema["mozPipelineMetadata"]["bq_metadata_format"] == "structured"
@@ -455,7 +463,7 @@ class TestGleanPing(object):
                 )
             if name == "dependency_ping":
                 # Need to do individual comparison due to update of value based on app_id
-                assert len(schema["mozPipelineMetadata"]) == 3
+                assert len(schema["mozPipelineMetadata"]) == 4
                 assert schema["mozPipelineMetadata"]["bq_dataset_family"] == "app1"
                 assert (
                     schema["mozPipelineMetadata"]["bq_metadata_format"] == "structured"
@@ -492,7 +500,7 @@ class TestGleanPing(object):
                 )
             if name == "dependency_ping":
                 # Need to do individual comparison due to update of value based on app_id
-                assert len(schema["mozPipelineMetadata"]) == 4
+                assert len(schema["mozPipelineMetadata"]) == 5
                 assert schema["mozPipelineMetadata"]["bq_dataset_family"] == "app1"
                 assert (
                     schema["mozPipelineMetadata"]["bq_metadata_format"] == "structured"
@@ -537,7 +545,7 @@ class TestGleanPing(object):
                 )
             if name == "dependency_ping":
                 # Need to do individual comparison due to update of value based on app_id
-                assert len(schema["mozPipelineMetadata"]) == 4
+                assert len(schema["mozPipelineMetadata"]) == 5
                 assert schema["mozPipelineMetadata"]["bq_dataset_family"] == "app1"
                 assert (
                     schema["mozPipelineMetadata"]["bq_metadata_format"] == "structured"
@@ -620,7 +628,7 @@ class TestGleanPing(object):
                 )
             if name == "dependency_ping":
                 # Need to do individual comparison due to update of value based on app_id
-                assert len(schema["mozPipelineMetadata"]) == 5
+                assert len(schema["mozPipelineMetadata"]) == 6
                 assert schema["mozPipelineMetadata"]["bq_dataset_family"] == "app1"
                 assert (
                     schema["mozPipelineMetadata"]["bq_metadata_format"] == "structured"
@@ -763,7 +771,7 @@ class TestGleanPing(object):
         # This should continue to work
         # even if the upstream schema actually gains those fields.
         json = generic_ping.GenericPing._get_json(
-            glean_ping.GleanPing.schema_url.format(branch="main")
+            glean_ping.DEFAULT_SCHEMA_URL.format(branch="main")
         )
         json.update(
             {
@@ -789,6 +797,7 @@ class TestGleanPing(object):
                 "bq_table": "metrics_v1",
                 "bq_metadata_format": "structured",
                 "json_object_path_regex": "metrics\\.object\\..*",
+                "include_info_sections": True,
             }
             for name, schema in final_schemas.items():
                 if name == "metrics":

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -618,9 +618,8 @@ class TestGleanPing(object):
             }
         ]
 
-        # TODO remove the temp branch name when the min schema pr lands
         glean = GleanPingNoInfoSection(
-            {"name": "app1", "app_id": "app1"}, mps_branch="wstuckey/glean-min"
+            {"name": "app1", "app_id": "app1"},
         )
         schemas = glean.generate_schema(config, generic_schema=True)
         final_schemas = {k: schemas[k].schema for k in schemas}


### PR DESCRIPTION
By using the `include_info_section` in the latest ping history we switch between `glean` and `glean-min` schemas which are created by https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/808