### PR TITLE
Don't fall back to glean-core if no dependencies are found for a repository

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -39,7 +39,7 @@ class GleanPing(GenericPing):
         GenericPing.probe_info_base_url + "/glean/{}/dependencies"
     )
 
-    default_dependencies = ["glean-core"]
+    default_dependencies = []
 
     with open(BUG_1737656_TXT, "r") as f:
         bug_1737656_affected_tables = [
@@ -92,7 +92,7 @@ class GleanPing(GenericPing):
                 self.dependencies_url_template.format(self.repo_name)
             )
         except HTTPError:
-            logging.info(f"For {self.repo_name}, using default Glean dependencies")
+            logging.info(f"No dependencies found for {self.repo_name}")
             return self.default_dependencies
 
         dependency_library_names = list(dependencies.keys())
@@ -109,7 +109,7 @@ class GleanPing(GenericPing):
                 dependencies.append(repos_by_dependency_name[name])
 
         if len(dependencies) == 0:
-            logging.info(f"For {self.repo_name}, using default Glean dependencies")
+            logging.info(f"No dependencies found for {self.repo_name}")
             return self.default_dependencies
 
         logging.info(f"For {self.repo_name}, found Glean dependencies: {dependencies}")


### PR DESCRIPTION
Requires https://github.com/mozilla/mozilla-schema-generator/pull/262

