### PR TITLE
Set glean app-level metadata for dependency pings

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -233,7 +233,7 @@ class GleanPing(GenericPing):
         # moz_pipeline_metadata_defaults so they need to be applied here.
 
         # 1.  Get repo and pipeline default metadata.
-        repos = GleanPing.get_repos()
+        repos = self.get_repos()
         current_repo = next((x for x in repos if x.get("app_id") == self.app_id), {})
         default_metadata = current_repo.get("moz_pipeline_metadata_defaults", {})
 

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -252,7 +252,7 @@ class GleanPing(GenericPing):
                 GleanPing.apply_default_metadata(
                     dependency_ping.get("moz_pipeline_metadata"), default_metadata
                 )
-                # ping-level properties take priority over repo defaults
+                # app-level ping properties take priority over the app defaults
                 metadata_override = app_metadata.get(dependency_ping["name"])
                 if metadata_override is not None:
                     GleanPing.apply_default_metadata(

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -238,6 +238,10 @@ class GleanPing(GenericPing):
         default_metadata = current_repo.get("moz_pipeline_metadata_defaults", {})
 
         # 2.  Apply the default metadata to each dependency defined ping.
+
+        # Apply app-level metadata to pings defined in dependencies
+        app_metadata = current_repo.get("moz_pipeline_metadata", {})
+
         for dependency in self.get_dependencies():
             dependency_pings = self._get_dependency_pings(dependency)
             for dependency_ping in dependency_pings.values():
@@ -248,7 +252,14 @@ class GleanPing(GenericPing):
                 GleanPing.apply_default_metadata(
                     dependency_ping.get("moz_pipeline_metadata"), default_metadata
                 )
+                # ping-level properties take priority over repo defaults
+                metadata_override = app_metadata.get(dependency_ping["name"])
+                if metadata_override is not None:
+                    GleanPing.apply_default_metadata(
+                        dependency_ping.get("moz_pipeline_metadata"), metadata_override
+                    )
             ping_data.update(dependency_pings)
+
         return ping_data
 
     @staticmethod


### PR DESCRIPTION
fixes https://github.com/mozilla/mozilla-schema-generator/issues/264

This applies `moz_pipeline_metadata` defined for the app to pings defined in dependencies. e.g. firefox_desktop.pageload

~~Merging this is dependent on a resolution for https://mozilla-hub.atlassian.net/browse/DSRE-1639 so we don't unexpectedly delete data for pageload~~

Ready for review now that https://github.com/mozilla/probe-scraper/pull/777 has been merged.

I tested this with `mozilla-schema-generator generate-glean-pings --out-dir out_dir` and the before and after diff is here https://github.com/mozilla/mozilla-schema-generator/commit/b5a68d088eb7a716fa3c5de94b54fe91d41818ff
The only difference is the `{"delete_after_days": 10000}` in pageload which seems correct