### PR TITLE
Freeze main_v4 schema

### DIFF
--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -50,7 +50,6 @@ function _generate_schemas() {
     mozilla-schema-generator generate-glean-pings \
         --mps-branch "$mps_branch_source" \
         --out-dir .
-    
     # Copy aliased schemas into place before handling subset pings
     alias_schemas "$ALIASES_PATH" .
 

--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -61,7 +61,7 @@ function _generate_schemas() {
     # This needs to be called at the end because it overwrites main_v4 schema that
     # is used to generate subset pings
     mozilla-schema-generator freeze-main-4-ping \
-        --out-dir .
+        --out-dir ./telemetry
 
     # Remove all non-json schemas (e.g. parquet)
     find . -not -name "*.schema.json" -type f -exec rm {} +

--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -50,12 +50,17 @@ function _generate_schemas() {
     mozilla-schema-generator generate-glean-pings \
         --mps-branch "$mps_branch_source" \
         --out-dir .
-
+    
     # Copy aliased schemas into place before handling subset pings
     alias_schemas "$ALIASES_PATH" .
 
     # Generate subset pings
     mozilla-schema-generator generate-subset-pings \
+        --out-dir .
+    
+    # This needs to be called at the end because it overwrites main_v4 schema that
+    # is used to generate subset pings
+    mozilla-schema-generator freeze-main-4-ping \
         --out-dir .
 
     # Remove all non-json schemas (e.g. parquet)

--- a/bin/generate_commit
+++ b/bin/generate_commit
@@ -50,6 +50,7 @@ function _generate_schemas() {
     mozilla-schema-generator generate-glean-pings \
         --mps-branch "$mps_branch_source" \
         --out-dir .
+
     # Copy aliased schemas into place before handling subset pings
     alias_schemas "$ALIASES_PATH" .
 

--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -8,6 +8,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from shutil import copyfile
 
 import click
 import yaml
@@ -88,6 +89,21 @@ def generate_main_ping(config, out_dir, pretty, mps_branch):
     schemas = schema_generator.generate_schema(config)
     # schemas introduces an extra layer to the actual schema
     dump_schema(schemas, out_dir, pretty, version=4)
+
+
+@click.command()
+@common_options
+def freeze_main_4_ping(out_dir, pretty, mps_branch):
+    # Copy the frozen main ping schema to the output directory
+    #
+    # We want to stop updating main_v4 schema, but we still need it in the generated
+    # artifact so the table not gets deleted by deployment pipeline.
+    # Frozen schema was copied from https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/9ef50e7478220f9917db20345cf3240da8f9774a/schemas/telemetry/main/main.4.schema.json # noqa E501
+    #
+    # This needs to be called after generate_main_ping and generate_subset_pings
+    frozen_main_4_ping_file = CONFIGS_DIR / "main.4.schema.json.20240612.9ef50e7"
+    main_4_path = out_dir + "/main/main.4.schema.json"
+    copyfile(frozen_main_4_ping_file, main_4_path)
 
 
 @click.command()
@@ -285,6 +301,7 @@ main.add_command(generate_bhr_ping)
 main.add_command(generate_glean_pings)
 main.add_command(generate_common_pings)
 main.add_command(generate_subset_pings)
+main.add_command(freeze_main_4_ping)
 
 
 if __name__ == "__main__":

--- a/mozilla_schema_generator/configs/main.4.schema.json.20240612.9ef50e7
+++ b/mozilla_schema_generator/configs/main.4.schema.json.20240612.9ef50e7
@@ -1,0 +1,3577 @@
+{
+  "$id": "moz://mozilla.org/schemas/main/ping/4",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "mozPipelineMetadata": {
+    "bq_dataset_family": "telemetry",
+    "bq_metadata_format": "telemetry",
+    "bq_table": "main_v4",
+    "split_config": {
+      "preserve_original": false,
+      "remainder": {
+        "document_namespace": "telemetry",
+        "document_type": "main",
+        "document_version": "5"
+      },
+      "subsets": [
+        {
+          "document_namespace": "telemetry",
+          "document_type": "main-use-counter",
+          "document_version": "4",
+          "pattern": ".*[.](USE_COUNTER2_[^.]+|((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED)"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "application": {
+      "additionalProperties": false,
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "buildId": {
+          "pattern": "^[0-9]{10}",
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "displayVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "buildId",
+        "channel",
+        "name",
+        "platformVersion",
+        "version",
+        "vendor",
+        "xpcomAbi"
+      ],
+      "type": "object"
+    },
+    "clientId": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "creationDate": {
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
+      "type": "string"
+    },
+    "environment": {
+      "properties": {
+        "addons": {
+          "properties": {
+            "activeAddons": {
+              "additionalProperties": {
+                "properties": {
+                  "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": "boolean"
+                  },
+                  "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": [
+                      "integer",
+                      "boolean"
+                    ]
+                  },
+                  "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": "boolean"
+                  },
+                  "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
+                    "type": "boolean"
+                  },
+                  "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": "string"
+                  },
+                  "quarantineIgnoredByApp": {
+                    "description": "Whether or not the add-on has quarantine ignored by the app.",
+                    "type": "boolean"
+                  },
+                  "quarantineIgnoredByUser": {
+                    "description": "Whether or not the add-on has quarantine ignored by the user.",
+                    "type": "boolean"
+                  },
+                  "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": "integer"
+                  },
+                  "signedTypes": {
+                    "description": "A JSON-stringified array of signature types found for the add-on.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": [
+                      "boolean",
+                      "integer"
+                    ]
+                  },
+                  "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            },
+            "activeExperiment": {
+              "properties": {
+                "branch": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "activeGMPlugins": {
+              "additionalProperties": {
+                "properties": {
+                  "applyBackgroundUpdates": {
+                    "type": [
+                      "integer",
+                      "boolean"
+                    ]
+                  },
+                  "userDisabled": {
+                    "type": "boolean"
+                  },
+                  "version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            },
+            "activePlugins": {
+              "items": {
+                "properties": {
+                  "blocklisted": {
+                    "type": "boolean"
+                  },
+                  "clicktoplay": {
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "mimeTypes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "updateDay": {
+                    "type": "integer"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "persona": {
+              "description": "The id of the active persona (theme).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "theme": {
+              "properties": {
+                "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
+                  "type": "boolean"
+                },
+                "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
+                  "type": [
+                    "boolean",
+                    "integer"
+                  ]
+                },
+                "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
+                  "type": "boolean"
+                },
+                "id": {
+                  "description": "The id of the theme.",
+                  "type": "string"
+                },
+                "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "The theme name, limited to 100 characters.",
+                  "type": "string"
+                },
+                "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
+                  "type": "integer"
+                },
+                "signedState": {
+                  "description": "The state of the signature of the theme.",
+                  "type": "integer"
+                },
+                "signedTypes": {
+                  "description": "A JSON-stringified array of signature types found for the theme.",
+                  "type": "string"
+                },
+                "updateDay": {
+                  "description": "The day the theme was last updated.",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
+                  "type": "boolean"
+                },
+                "version": {
+                  "description": "The version of the theme.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "build": {
+          "properties": {
+            "applicationId": {
+              "description": "The application UUID.",
+              "type": "string"
+            },
+            "applicationName": {
+              "description": "The application name.",
+              "type": "string"
+            },
+            "architecture": {
+              "description": "The build architecture for the active build.",
+              "type": "string"
+            },
+            "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
+              "type": "string"
+            },
+            "buildId": {
+              "description": "The build ID/date of the application.",
+              "pattern": "^[0-9]{10}",
+              "type": "string"
+            },
+            "displayVersion": {
+              "description": "The display version of the application.",
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "hotfixVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "platformVersion": {
+              "description": "The version of the XULRunner platform.",
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
+              "type": "boolean"
+            },
+            "vendor": {
+              "description": "The application vendor.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "version": {
+              "description": "The version of the application.",
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "applicationId",
+            "applicationName",
+            "architecture",
+            "buildId",
+            "version",
+            "vendor",
+            "platformVersion",
+            "xpcomAbi"
+          ],
+          "type": "object"
+        },
+        "experiments": {
+          "additionalProperties": {
+            "properties": {
+              "branch": {
+                "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "partner": {
+          "properties": {
+            "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributor": {
+              "description": "The value of the `app.distributor` pref.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "profile": {
+          "properties": {
+            "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
+              "type": "number"
+            },
+            "firstUseDate": {
+              "type": "number"
+            },
+            "isStubProfile": {
+              "type": "boolean"
+            },
+            "recoveredFromBackup": {
+              "description": "The date the user profile was recovered from a backup, as the integer number of days since UNIX epoch. This is optional.",
+              "type": "number"
+            },
+            "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "services": {
+          "properties": {
+            "accountEnabled": {
+              "type": "boolean"
+            },
+            "syncEnabled": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "settings": {
+          "properties": {
+            "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
+              "type": "boolean"
+            },
+            "attribution": {
+              "properties": {
+                "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
+                  "type": "string"
+                },
+                "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
+                  "type": "string"
+                },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
+                  "type": "string"
+                },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
+                "experiment": {
+                  "description": "funnel experiment parameters, see bug 1567339",
+                  "type": "string"
+                },
+                "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
+                  "type": "string"
+                },
+                "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
+                  "type": "string"
+                },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "funnel experiment parameters, see bug 1567339",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
+              "type": "boolean"
+            },
+            "defaultPrivateSearchEngine": {
+              "type": "string"
+            },
+            "defaultPrivateSearchEngineData": {
+              "properties": {
+                "loadPath": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "origin": {
+                  "type": "string"
+                },
+                "submissionURL": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
+              "type": "string"
+            },
+            "defaultSearchEngineData": {
+              "properties": {
+                "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "The name of the default search engine.",
+                  "type": "string"
+                },
+                "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
+                  "type": "string"
+                },
+                "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "e10sCohort": {
+              "type": "string"
+            },
+            "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
+              "type": "boolean"
+            },
+            "e10sMultiProcesses": {
+              "description": "maximum number of processes that will be launched for regular web content",
+              "type": "integer"
+            },
+            "fissionEnabled": {
+              "description": "whether fission is enabled this session, and subframes can load in a different process",
+              "type": "boolean"
+            },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "launcherProcessState": {
+              "type": "integer"
+            },
+            "locale": {
+              "description": "The best locale that the application should be localized to.",
+              "type": "string"
+            },
+            "sandbox": {
+              "properties": {
+                "contentWin32kLockdownState": {
+                  "description": "The status of Win32k Lockdown for Content process.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "searchCohort": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
+              "type": "boolean"
+            },
+            "update": {
+              "properties": {
+                "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
+                  "type": "boolean"
+                },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
+                "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "userPrefs": {
+              "additionalProperties": {
+                "type": [
+                  "boolean",
+                  "string",
+                  "number",
+                  "null"
+                ]
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "system": {
+          "properties": {
+            "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cpu": {
+              "properties": {
+                "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
+                  "maximum": 2048,
+                  "minimum": 1,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
+                  "maximum": 1024,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "isWindowsSMode": {
+                  "description": "Whether or not the system is Windows 10 or 11 in S Mode. S Mode existed prior to us being able to query it, so this is unreliable on Windows versions prior to 1810.",
+                  "type": "boolean"
+                },
+                "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "device": {
+              "properties": {
+                "hardware": {
+                  "type": "string"
+                },
+                "isTablet": {
+                  "type": "boolean"
+                },
+                "manufacturer": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "gfx": {
+              "properties": {
+                "ContentBackend": {
+                  "description": "The name of the content backend.",
+                  "type": "string"
+                },
+                "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "EmbeddedInFirefoxReality": {
+                  "description": "Whether or not Firefox desktop is embedded by Firefox Reality. This is Windows only.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "LowEndMachine": {
+                  "type": "boolean"
+                },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
+                "adapters": {
+                  "items": {
+                    "properties": {
+                      "GPUActive": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "RAM": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "deviceID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVersion": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "subsysID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "vendorID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "features": {
+                  "properties": {
+                    "advancedLayers": {
+                      "properties": {
+                        "noConstantBufferOffsetting": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "d2d": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "version": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "d3d11": {
+                      "properties": {
+                        "blacklisted": {
+                          "description": "Indicates whether the d3d11 compositor was blocklisted due to driver bugs. (This field was renamed to blocklisted in bug 1647225).",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "blocklisted": {
+                          "description": "Indicates whether the d3d11 compositor was blocklisted due to driver bugs. (This field replaces blacklisted as of bug 1647225).",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "textureSharing": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "version": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "warp": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "gpuProcess": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "hwCompositing": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "omtp": {
+                      "description": "Indicates whether the off-main-thread painting is enabled.",
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "openglCompositing": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "webrender": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "wrCompositor": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "wrQualified": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "wrSoftware": {
+                      "description": "Indicates whether the software backend to WebRender is enabled.",
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "monitors": {
+                  "items": {
+                    "properties": {
+                      "pseudoDisplay": {
+                        "type": "boolean"
+                      },
+                      "refreshRate": {
+                        "type": "number"
+                      },
+                      "scale": {
+                        "type": "number"
+                      },
+                      "screenHeight": {
+                        "type": "integer"
+                      },
+                      "screenWidth": {
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "hasWinPackageId": {
+              "description": "Is the process running with a package identity (e.g. from an MSIX install)? See bug 1709892. This is Windows only.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "hdd": {
+              "properties": {
+                "binary": {
+                  "properties": {
+                    "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "profile": {
+                  "properties": {
+                    "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "system": {
+                  "properties": {
+                    "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
+              "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "memoryMB": {
+              "description": "The machines amount of RAM.",
+              "type": "number"
+            },
+            "os": {
+              "properties": {
+                "distro": {
+                  "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "distroVersion": {
+                  "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
+                  "type": "string"
+                },
+                "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
+                  "type": "string"
+                },
+                "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
+                  "type": "number"
+                },
+                "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
+                  "type": "number"
+                },
+                "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
+                  "type": [
+                    "string"
+                  ]
+                },
+                "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
+                  "type": "number"
+                },
+                "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "sec": {
+              "properties": {
+                "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "build",
+        "partner",
+        "settings",
+        "system"
+      ],
+      "type": "object"
+    },
+    "id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "payload": {
+      "properties": {
+        "UIMeasurements": {
+          "items": {
+            "properties": {
+              "action": {
+                "type": "string"
+              },
+              "extras": {
+                "type": "string"
+              },
+              "method": {
+                "type": "string"
+              },
+              "timestamp": {
+                "type": "number"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "addonDetails": {
+          "properties": {},
+          "type": "object"
+        },
+        "addonHistograms": {
+          "properties": {},
+          "type": "object"
+        },
+        "fileIOReports": {
+          "properties": {},
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "histograms": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "bucket_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "histogram_type": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "log_sum": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "log_sum_squares": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "range": {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              "sum": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sum_squares_hi": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sum_squares_lo": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "values": {
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^[0-9]+$": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "info": {
+          "properties": {
+            "addons": {
+              "description": "obsolete, use environment.addons",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "asyncPluginInit": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "flashVersion": {
+              "description": "obsolete, use environment.addons.activePlugins",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "previousBuildId": {
+              "description": "null if this is the first run, or the previous build ID is unknown",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "previousSessionId": {
+              "description": "session id of the previous session, null on first run.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "previousSubsessionId": {
+              "description": "subsession id of the previous subsession (even if it was in a different session), null on first run.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "profileSubsessionCounter": {
+              "description": "the running no. of all subsessions for the whole profile life time",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "reason": {
+              "description": "what triggered this ping e.g. saved-session, environment-change, shutdown, ...",
+              "type": "string"
+            },
+            "revision": {
+              "description": "the Histograms.json revision",
+              "type": "string"
+            },
+            "sessionId": {
+              "description": "random session id, shared by subsessions",
+              "type": "string"
+            },
+            "sessionLength": {
+              "description": "the session length until now in seconds, monotonic; some clients report erroneous negative values",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "sessionStartDate": {
+              "description": "hourly precision, ISO date in local time",
+              "type": "string"
+            },
+            "subsessionCounter": {
+              "description": "the running no. of this subsession since the start of the browser session",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "subsessionId": {
+              "description": "random subsession id",
+              "type": "string"
+            },
+            "subsessionLength": {
+              "description": "the subsession length until now in seconds, monotonic",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "subsessionStartDate": {
+              "description": "hourly precision, ISO date in local time",
+              "type": "string"
+            },
+            "timezoneOffset": {
+              "description": "time-zone offset from UTC, in minutes, for the current locale",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "keyedHistograms": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "bucket_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "histogram_type": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "log_sum": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "log_sum_squares": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "range": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "sum": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "sum_squares_hi": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "sum_squares_lo": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^[0-9]+$": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "lateWrites": {
+          "description": "This sections reports writes to the file system that happen during shutdown. The reported data contains the stack and the file names of the loaded libraries at the time the writes happened.",
+          "properties": {
+            "isFromTerminatorWatchdog": {
+              "description": "Bug 1634520 - 1 if the late writes began in nsTerminator, 0 otherwise",
+              "type": "integer"
+            },
+            "memoryMap": {
+              "description": "entries in the format [module name, breakpad identifier]",
+              "items": {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "stacks": {
+              "description": "A list of stacks",
+              "items": {
+                "description": "A list of stack frames, entries in the format [module index, program counter offset]. The module index can be -1 for invalid module indices. The program counter can be an offset in the module or an absolute pc.",
+                "items": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "processes": {
+          "properties": {
+            "content": {
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
+                        "items": {
+                          "type": "integer"
+                        },
+                        "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^[0-9]+$": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^[0-9]+$": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "dynamic": {
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
+                        "items": {
+                          "type": "integer"
+                        },
+                        "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^[0-9]+$": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^[0-9]+$": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "extension": {
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
+                        "items": {
+                          "type": "integer"
+                        },
+                        "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^[0-9]+$": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^[0-9]+$": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "gpu": {
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
+                        "items": {
+                          "type": "integer"
+                        },
+                        "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^[0-9]+$": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^[0-9]+$": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "parent": {
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
+                        "items": {
+                          "type": "integer"
+                        },
+                        "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^[0-9]+$": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^[0-9]+$": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "required": [
+                "scalars"
+              ],
+              "type": "object"
+            },
+            "socket": {
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
+                        "items": {
+                          "type": "integer"
+                        },
+                        "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^[0-9]+$": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^[0-9]+$": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "parent"
+          ],
+          "type": "object"
+        },
+        "simpleMeasurements": {
+          "properties": {},
+          "type": "object"
+        },
+        "slowSQL": {
+          "description": "Slow SQL queries for both the main and other threads. The execution of an SQL statement is considered slow if it takes 50ms or more on the main thread or 100ms or more on other threads. Slow SQL statements will be automatically trimmed to 1000 characters.",
+          "properties": {
+            "mainThread": {
+              "patternProperties": {
+                "^.*$": {
+                  "description": "Entries in the format [hitCount, totalTime]",
+                  "items": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "integer"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "otherThreads": {
+              "patternProperties": {
+                "^.*$": {
+                  "description": "Entries in the format [hitCount, totalTime]",
+                  "items": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "integer"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "slowSQLStartup": {
+          "properties": {},
+          "type": "object"
+        },
+        "ver": {
+          "type": "integer"
+        },
+        "webrtc": {
+          "properties": {},
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "type": {
+      "enum": [
+        "main",
+        "saved-session",
+        "first-shutdown"
+      ],
+      "type": "string"
+    },
+    "version": {
+      "maximum": 4,
+      "minimum": 4,
+      "type": "number"
+    }
+  },
+  "required": [
+    "application",
+    "creationDate",
+    "clientId",
+    "id",
+    "type",
+    "version"
+  ],
+  "title": "main",
+  "type": "object"
+}


### PR DESCRIPTION
This freezes main_v4 schema by overwriting it with the version generated on 2024-06-12. This will stop schema updates to main_v4 and will save us from having to bump maximum schema size again.

Tested by running:
```
mozilla-schema-generator generate-main-ping --out-dir telemetry-test
mozilla-schema-generator freeze-main-4-ping --out-dir telemetry-test
```

Before the merge we should confirm that this PR contains the latest schema from https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/generated-schemas/schemas/telemetry/main/main.4.schema.json