### PR TITLE
#1898105 Only use latest value for include_info_section

### DIFF
--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -78,3 +78,7 @@ accounts-backend.metrics.*
 moso-mastodon-backend.baseline.*
 moso-mastodon-backend.deletion-request.*
 moso-mastodon-backend.metrics.*
+
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1898105
+# Delete User Characteristics pings to support no_info pings
+firefox-desktop.user-characteristics.*

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -312,7 +312,9 @@ class GleanPing(GenericPing):
         """Return false if the field exists and is false.
 
         If `consider_all_history` is False, then only check the latest value in the ping history.
-        Otherwise, if the field is not found or true in one or more history entries, true is returned.
+
+        Otherwise, if the field is not found or true in one or more history entries,
+        true is returned.
         """
 
         # Default to true if not specified.
@@ -327,13 +329,12 @@ class GleanPing(GenericPing):
         # and https://bugzilla.mozilla.org/show_bug.cgi?id=1898105#c10
         ping_history: list
         if consider_all_history:
-           ping_history = ping_data['history'] 
+            ping_history = ping_data['history']
         else:
             ping_history = [ping_data['history'][-1]]
         for history in ping_history:
             if field_name not in history or history[field_name]:
                 return True
-
 
         # The ping was created with include_info_sections = False. The fields can be excluded.
         return False

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -329,9 +329,9 @@ class GleanPing(GenericPing):
         # and https://bugzilla.mozilla.org/show_bug.cgi?id=1898105#c10
         ping_history: list
         if consider_all_history:
-            ping_history = ping_data['history']
+            ping_history = ping_data["history"]
         else:
-            ping_history = [ping_data['history'][-1]]
+            ping_history = [ping_data["history"][-1]]
         for history in ping_history:
             if field_name not in history or history[field_name]:
                 return True

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -165,6 +165,7 @@ class GleanPingNoInfoSection(GleanPingStub):
     def _get_history(self):
         return [{"include_info_sections": False}]
 
+
 class GleanPingNoInfoSectionWithHistory(GleanPingStub):
     ping_metadata = {
         "bq_dataset_family": "app1",


### PR DESCRIPTION
Rolling back the change to check the full history for `include_info_sections`. The new plan is to no longer allow the migrations from `include_info_sections: true` -> `include_info_sections: false` 

Also added the offending ping to the incompatibility allowlist