### PR TITLE
Prevent glean metadata overrides form overwriting default metadata

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import copy
 import logging
 from pathlib import Path
 from typing import Dict, List, Set
@@ -250,7 +251,8 @@ class GleanPing(GenericPing):
                 # bq_dataset_family instead of using the dependency id for the bq_dataset_family
                 # value.
                 GleanPing.apply_default_metadata(
-                    dependency_ping.get("moz_pipeline_metadata"), default_metadata
+                    dependency_ping.get("moz_pipeline_metadata"),
+                    copy.deepcopy(default_metadata),
                 )
                 # app-level ping properties take priority over the app defaults
                 metadata_override = app_metadata.get(dependency_ping["name"])

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -278,6 +278,9 @@ class GleanPingWithMetadataOverrides(GleanPingStub):
                         "override_attributes": [{"name": "geo_city", "value": None}],
                     },
                 },
+                "moz_pipeline_metadata_defaults": {
+                    "expiration_policy": {"delete_after_days": 80}
+                },
             }
         ]
 
@@ -946,6 +949,9 @@ class TestGleanPing(object):
             **glean._get_ping_data_without_dependencies(),
             **glean._get_dependency_pings(""),
         }
+        expected_pings["dependency_ping1"]["moz_pipeline_metadata"][
+            "expiration_policy"
+        ] = {"delete_after_days": 80}
         expected_pings["dependency_ping2"]["moz_pipeline_metadata"][
             "expiration_policy"
         ] = {"delete_after_days": 90}


### PR DESCRIPTION
https://github.com/mozilla/mozilla-schema-generator/pull/266 introduced a bug where the metadata for a ping set at the app-level might overwrite the app defaults in `moz_pipeline_metadata_defaults`.  This is because `GleanPing.apply_default_metadata` is called twice and the first call puts the `default_metadata` dict in the ping and then the second call will update that dict in place so the `default_metadata` will then have new values.

For example, this can be seen in [`pine.deletion-request`](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/4be954bed819451f970c026a44b5c07c68ce18ba/schemas/pine/deletion-request/deletion-request.1.schema.json#L11) where the retention is set to 1130 but it's set to 10000 in [probe-scraper](https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml#L525).

I made a pr against the generated schemas to show the changes this would make on the schemas https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/827.  I'll go through those and make sure those are correct and won't unexpectedly delete things.  All the changes are decreases in retention period except for pine deletion-requests and pageload which means that this bug shouldn't have deleted anything unexpectedly.