### PR TITLE
Bug 1932210 - Add labeled_quantity glean metric type

### DIFF
--- a/mozilla_schema_generator/configs/glean.yaml
+++ b/mozilla_schema_generator/configs/glean.yaml
@@ -89,6 +89,12 @@ metrics:
         not:
           - glean_ping_info
       type: labeled_string
+  labeled_quantity:
+    match:
+      send_in_pings:
+        not:
+          - glean_ping_info
+      type: labeled_quantity
 
   # Metric types affected by https://bugzilla.mozilla.org/show_bug.cgi?id=1737656
   # The jwe, labeled_rate, url, and text types were deployed to BigQuery tables


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1932210

Following the instructions in https://github.com/mozilla/glean/blob/main/docs/dev/core/new-metric-type/platform.md

Goes with https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/831