### PR TITLE
CI: Use newer Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,12 +78,12 @@ jobs:
 
   deploy:
     docker:
-      - image: docker:20.10.2
+      - image: cimg/base:default
     working_directory: ~/mozilla/mozilla-schema-generator
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.2
+          version: docker24
       - run: |
           printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BUILD_URL" > version.json
       - run: docker build -t app:build .


### PR DESCRIPTION
The previous used one is unsupported on CircleCI now. The build task fails with a message:

Job was rejected because this version of Docker is not supported on this resource class. Try removing the version of Docker in your .circleci/config.yml and re-running

See https://app.circleci.com/pipelines/github/mozilla/mozilla-schema-generator/2529/workflows/a9b16e17-d4a7-486a-a7c7-486d2992705d/jobs/3396

I guess this might fix it?