### PR TITLE
CI: update Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,12 +78,12 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/base:default
+      - image: docker/compose:1.22.0
     working_directory: ~/mozilla/mozilla-schema-generator
     steps:
       - checkout
       - setup_remote_docker:
-          version: docker24
+          version: default
       - run: |
           printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BUILD_URL" > version.json
       - run: docker build -t app:build .


### PR DESCRIPTION
Hopefully fixes https://github.com/mozilla/mozilla-schema-generator/pull/282.

This is the same image that's used in gcp-ingestion for publishing to Dockerhub: https://github.com/mozilla/gcp-ingestion/blob/50eb31f6dc79021cab1cc222a6799d3896a62a9c/.circleci/config.yml#L135.