### PR TITLE
Add empty doctypes to incompatability-allowlist

### DIFF
--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -92,3 +92,7 @@ mozza.*
 
 # DSRE-1815
 mlhackweek-search.*
+
+# DSRE-1832
+telemetry.block-autoplay.1
+firefox-accounts.*


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DSRE-1832

`firefox-accounts` isn't empty, it's just the doctypes in https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/main/schemas/firefox-accounts that are being deleted