### PR TITLE
DENG-4097 - Remove BQ schemas for main_v4 and related tables

### DIFF
--- a/disallowlist
+++ b/disallowlist
@@ -7,3 +7,6 @@ metadata/metaschema/.*
 glean/.*
 telemetry/disableSHA1rollout/.*
 telemetry/untrustedModules/.*
+telemetry/main/main.4.bq
+telemetry/first-shutdown/first-shutdown.4.bq
+telemetry/saved-session/saved-session.4.bq

--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -92,3 +92,8 @@ mozza.*
 
 # DSRE-1815
 mlhackweek-search.*
+
+# DENG-4097
+telemetry.main.4
+telemetry.first-shutdown.4
+telemetry.saved-session.4


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/DENG-4097?focusedCommentId=1026418

This removes BigQuery schemas for {main,saved-session,first-shutdown}_v4.
JSON schemas for these pings are still generated because we need them for validation at ingestion.

Tested with:

```
export MPS_REPO_URL="git@github.com:akkomar/mozilla-pipeline-schemas.git"
export MPS_SSH_KEY_BASE64="..."
make build
make run
```

Comparison of branch produced with above test vs latest production generated-schemas:
https://github.com/mozilla-services/mozilla-pipeline-schemas/compare/generated-schemas..akkomar:mozilla-pipeline-schemas:test-generated-schemas?expand=1