### PR TITLE
[DENG-8496] Add telemetry.modules to incompatibility list

### DIFF
--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -92,3 +92,6 @@ mozza.*
 
 # DSRE-1815
 mlhackweek-search.*
+
+# DENG-8496
+telemetry.modules.4


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-8496

Should be merged with https://github.com/mozilla/bigquery-etl/pull/7778
