### PR TITLE
[DENG-8496] Remove modules_v4 from common pings

### DIFF
--- a/common_pings.json
+++ b/common_pings.json
@@ -13,9 +13,6 @@
         "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/crash/crash.4.schema.json"
     },
     {
-        "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/modules/modules.4.schema.json"
-    },
-    {
         "schema_url": "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/{branch}/schemas/telemetry/testpilot/testpilot.4.schema.json"
     },
     {


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-8496

Should have been done with https://github.com/mozilla/mozilla-schema-generator/pull/292