### PR TITLE
[DENG-8494] Add fenix and desktop metrics to glean v2 allowlist

### DIFF
--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -188,7 +188,7 @@ def generate_glean_pings(config, out_dir, pretty, mps_branch, repo, generic_sche
         v2_allowlist = yaml.safe_load(f)
 
     with open(CONFIGS_DIR / "glean_v1_overwrite_allowlist.yaml", "r") as f:
-        v1_overwrite_allowlist = yaml.safe_load(f) or []
+        v1_overwrite_allowlist = yaml.safe_load(f) or {}
 
     # validate that the config has mappings for every single metric type specified in the
     # Glean schema (see: https://bugzilla.mozilla.org/show_bug.cgi?id=1739239)
@@ -230,31 +230,49 @@ def write_schema(
     v2_allowlist,
     v1_overwrite_allowlist,
 ):
-    for version in (1, 2):
-        if version == 2 and (
-            repo["app_id"] in v1_overwrite_allowlist
-            or repo["app_id"] not in v2_allowlist
-        ):
-            continue
+    v2_pings = set(v2_allowlist.get(repo["app_id"], []))
+    overwrite_pings = set(v1_overwrite_allowlist.get(repo["app_id"]) or [])
 
-        use_metrics_blocklist = version == 2 or repo["app_id"] in v1_overwrite_allowlist
+    for version in (1, 2):
+        if version == 2 and not v2_pings:
+            continue
 
         schema_generator = GleanPing(
             repo,
             mps_branch=mps_branch,
             version=version,
-            use_metrics_blocklist=use_metrics_blocklist,
+            use_metrics_blocklist=version == 2,
         )
         schemas = schema_generator.generate_schema(
             config, generic_schema=generic_schema
         )
 
-        # only keep pings that are in the allowlist
+        # for v1_overwrite pings, the v2 schema gets written to .1.schema.json
         if version == 2:
+            overwrites = {
+                name: schema
+                for name, schema in schemas.items()
+                if name in overwrite_pings
+            }
             schemas = {
                 name: schema
                 for name, schema in schemas.items()
-                if name in v2_allowlist[repo["app_id"]]
+                if name in v2_pings - overwrite_pings
+            }
+            if overwrites:
+                dump_schema(
+                    overwrites,
+                    out_dir and out_dir.joinpath(repo["app_id"]),
+                    pretty,
+                    version=1,
+                )
+            if not schemas:
+                continue
+        elif overwrite_pings:
+            schemas = {
+                name: schema
+                for name, schema in schemas.items()
+                if name not in overwrite_pings
             }
 
         dump_schema(

--- a/mozilla_schema_generator/configs/glean_v1_overwrite_allowlist.yaml
+++ b/mozilla_schema_generator/configs/glean_v1_overwrite_allowlist.yaml
@@ -1,46 +1,50 @@
-# app ids to replace glean v1 with v2
-# needed temporarily because not all apps will be changed at the same time
-#- accounts-cirrus
-#- burnham
-#- experimenter-cirrus
-#- firefox-crashreporter
-#- firefox-desktop
-#- firefox-desktop-background-defaultagent
-#- firefox-desktop-background-tasks
-#- firefox-desktop-background-update
-#- monitor-cirrus
-#- mozilla-lockbox
-#- mozilla-mach
-#- mozillavpn
-#- mozillavpn-backend-cirrus
-#- mozphab
-#- net-thunderbird-android
-#- net-thunderbird-android-beta
-#- net-thunderbird-android-daily
-#- org-mozilla-connect-firefox
-#- org-mozilla-fenix
-#- org-mozilla-fenix-nightly
-#- org-mozilla-fennec-aurora
-#- org-mozilla-firefox
-#- org-mozilla-firefox-beta
-#- org-mozilla-firefox-vpn
-#- org-mozilla-firefoxreality
-#- org-mozilla-focus
-#- org-mozilla-focus-beta
-#- org-mozilla-focus-nightly
-#- org-mozilla-ios-fennec
-#- org-mozilla-ios-firefox
-#- org-mozilla-ios-firefoxbeta
-#- org-mozilla-ios-firefoxvpn
-#- org-mozilla-ios-firefoxvpn-network-extension
-#- org-mozilla-ios-focus
-#- org-mozilla-ios-klar
-#- org-mozilla-ios-lockbox
-#- org-mozilla-klar
-#- org-mozilla-mozregression
-#- org-mozilla-reference-browser
-#- org-mozilla-social-nightly
-#- org-mozilla-tv-firefox
-#- org-mozilla-vrbrowser
-#- pine
-#- thunderbird-desktop
+# app id -> pings to replace glean v1 schemas with v2
+# Needed temporarily because not all apps and pings will be changed at the same time
+# For pings that are also in glean_v2_allowlist.yaml, if they are also here, they will no longer
+# produce a v2 schema file  and the v1 schema file will have the v2 schema.
+# If they are not here, they will produce a v1 and a v2 schema file.
+
+#accounts-cirrus:
+#burnham:
+#experimenter-cirrus:
+#firefox-crashreporter:
+#firefox-desktop:
+#firefox-desktop-background-defaultagent:
+#firefox-desktop-background-tasks:
+#firefox-desktop-background-update:
+#monitor-cirrus:
+#mozilla-lockbox:
+#mozilla-mach:
+#mozillavpn:
+#mozillavpn-backend-cirrus:
+#mozphab:
+#net-thunderbird-android:
+#net-thunderbird-android-beta:
+#net-thunderbird-android-daily:
+#org-mozilla-connect-firefox:
+#org-mozilla-fenix:
+#org-mozilla-fenix-nightly:
+#org-mozilla-fennec-aurora:
+#org-mozilla-firefox:
+#org-mozilla-firefox-beta:
+#org-mozilla-firefox-vpn:
+#org-mozilla-firefoxreality:
+#org-mozilla-focus:
+#org-mozilla-focus-beta:
+#org-mozilla-focus-nightly:
+#org-mozilla-ios-fennec:
+#org-mozilla-ios-firefox:
+#org-mozilla-ios-firefoxbeta:
+#org-mozilla-ios-firefoxvpn:
+#org-mozilla-ios-firefoxvpn-network-extension:
+#org-mozilla-ios-focus:
+#org-mozilla-ios-klar:
+#org-mozilla-ios-lockbox:
+#org-mozilla-klar:
+#org-mozilla-mozregression:
+#org-mozilla-reference-browser:
+#org-mozilla-social-nightly:
+#org-mozilla-tv-firefox:
+#org-mozilla-vrbrowser:
+#pine:
+#thunderbird-desktop:

--- a/mozilla_schema_generator/configs/glean_v2_allowlist.yaml
+++ b/mozilla_schema_generator/configs/glean_v2_allowlist.yaml
@@ -11,8 +11,8 @@
 # firefox-crashreporter:
 # - metrics
 # - health
-# firefox-desktop:
-# - metrics
+firefox-desktop:
+- metrics
 # - health
 # - sync
 # - captcha-detection
@@ -63,8 +63,8 @@
 # org-mozilla-connect-firefox:
 # - metrics
 # - health
-# org-mozilla-fenix:
-# - metrics
+org-mozilla-fenix:
+- metrics
 # - sync
 # - health
 # - first-session
@@ -84,15 +84,15 @@ org-mozilla-fennec-aurora:
 - first-session
 - health
 - adjust-attribution
-# org-mozilla-firefox:
-# - metrics
+org-mozilla-firefox:
+- metrics
 # - health
 # - sync
 # - first-session
 # - captcha-detection
 # - adjust-attribution
-# org-mozilla-firefox-beta:
-# - metrics
+org-mozilla-firefox-beta:
+- metrics
 # - health
 # - sync
 # - first-session

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -2,7 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+from collections import defaultdict
 from typing import Dict, List
 from unittest.mock import patch
 
@@ -1225,10 +1225,33 @@ class TestGleanPing(object):
 
 
 class TestGleanGeneration:
+    # pings to use for all apps
+    PING_TYPES = ("metrics", "health", "baseline")
+
     @pytest.fixture
     def mock_glean_ping(self):
+        """Return a GleanPing object that mock generates schemas for each ping in PING_TYPES."""
+
+        def make_instance(repo, *, mps_branch, version, use_metrics_blocklist):
+            instance = mock.MagicMock()
+            instance.generate_schema.return_value = {
+                ping: f"{ping}-v{version}" for ping in self.PING_TYPES
+            }
+            return instance
+
         with mock.patch("mozilla_schema_generator.__main__.GleanPing") as mock_glean:
+            mock_glean.side_effect = make_instance
             yield mock_glean
+
+    @staticmethod
+    def dump_calls_by_version(dump_schema_mock):
+        """Return {version: [schemas_dict, ...]} for each dump_schema call."""
+        by_version = defaultdict(list)
+        for call in dump_schema_mock.call_args_list:
+            schemas = call.args[0]
+            version = call.kwargs["version"]
+            by_version[version].append(schemas)
+        return by_version
 
     @pytest.fixture
     def glean_v2_allowlist(self):
@@ -1240,11 +1263,18 @@ class TestGleanGeneration:
             "org-mozilla-firefox": [
                 "metrics",
             ],
+            "partial-overwrite-app": [
+                "metrics",
+                "health",
+            ],
         }
 
     @pytest.fixture
     def glean_v1_overwrite_allowlist(self):
-        return ["firefox-desktop"]
+        return {
+            "firefox-desktop": ["metrics", "health"],
+            "partial-overwrite-app": ["metrics"],
+        }
 
     @patch("mozilla_schema_generator.__main__.dump_schema")
     def test_v2_allowlist_write_v1_v2(
@@ -1255,7 +1285,7 @@ class TestGleanGeneration:
         glean_v2_allowlist,
         glean_v1_overwrite_allowlist,
     ):
-        """Should write both v1 and v2 when in v2 allowlist but not v1_overwrite."""
+        """Pings in v2 allowlist but not v1_overwrite should write both v1 and v2 schemas."""
         repo = {"app_id": "org-mozilla-firefox"}
 
         msg_main.write_schema(
@@ -1277,6 +1307,12 @@ class TestGleanGeneration:
             repo, mps_branch="", version=2, use_metrics_blocklist=True
         )
 
+        by_version = self.dump_calls_by_version(dump_schema)
+        # write every v1 ping
+        assert by_version[1] == [{ping: f"{ping}-v1" for ping in self.PING_TYPES}]
+        # only the v2 allowlisted ping
+        assert by_version[2] == [{"metrics": "metrics-v2"}]
+
     @patch("mozilla_schema_generator.__main__.dump_schema")
     def test_v2_allowlist_overwrite_v1(
         self,
@@ -1286,7 +1322,7 @@ class TestGleanGeneration:
         glean_v2_allowlist,
         glean_v1_overwrite_allowlist,
     ):
-        """Should write only v1 with metrics blocklist when in v1_overwrite allowlist."""
+        """Pings in v2 allowlist and v1_overwrite should only write v1 files with the v2 schema."""
         repo = {"app_id": "firefox-desktop"}
 
         msg_main.write_schema(
@@ -1300,10 +1336,76 @@ class TestGleanGeneration:
             v1_overwrite_allowlist=glean_v1_overwrite_allowlist,
         )
 
-        assert mock_glean_ping.call_count == 1
-        mock_glean_ping.assert_any_call(
-            repo, mps_branch="", version=1, use_metrics_blocklist=True
+        assert mock_glean_ping.call_count == 2
+
+        by_version = self.dump_calls_by_version(dump_schema)
+        # v2 schemas are written to .1.schema.json, non-allowlisted v1 schemas unchanged
+        assert sorted(by_version[1], key=lambda d: sorted(d)) == [
+            {"baseline": "baseline-v1"},
+            {"health": "health-v2", "metrics": "metrics-v2"},
+        ]
+        assert 2 not in by_version
+
+    @patch("mozilla_schema_generator.__main__.dump_schema")
+    def test_v2_allowlist_partial_overwrite(
+        self,
+        dump_schema,
+        mock_glean_ping,
+        config,
+        glean_v2_allowlist,
+        glean_v1_overwrite_allowlist,
+    ):
+        """Only v1_overwrite pings for an app should write to v1 files."""
+        repo = {"app_id": "partial-overwrite-app"}
+
+        msg_main.write_schema(
+            repo,
+            config,
+            out_dir=None,
+            pretty=True,
+            generic_schema=False,
+            mps_branch="",
+            v2_allowlist=glean_v2_allowlist,
+            v1_overwrite_allowlist=glean_v1_overwrite_allowlist,
         )
+
+        assert mock_glean_ping.call_count == 2
+
+        by_version = self.dump_calls_by_version(dump_schema)
+        # only metrics is v1_overwrite allowlisted while health continues to write to v2 and v1
+        assert sorted(by_version[1], key=lambda d: sorted(d)) == [
+            {"health": "health-v1", "baseline": "baseline-v1"},
+            {"metrics": "metrics-v2"},
+        ]
+        assert by_version[2] == [{"health": "health-v2"}]
+
+    @patch("mozilla_schema_generator.__main__.dump_schema")
+    def test_v2_allowlist_overwrite_entry_with_no_pings_is_noop(
+        self,
+        dump_schema,
+        mock_glean_ping,
+        config,
+        glean_v2_allowlist,
+    ):
+        """An app in v1_overwrite with an empty/null ping list should be a no-op."""
+        repo = {"app_id": "org-mozilla-firefox"}
+
+        msg_main.write_schema(
+            repo,
+            config,
+            out_dir=None,
+            pretty=True,
+            generic_schema=False,
+            mps_branch="",
+            v2_allowlist=glean_v2_allowlist,
+            v1_overwrite_allowlist={"org-mozilla-firefox": None},
+        )
+
+        assert mock_glean_ping.call_count == 2
+
+        by_version = self.dump_calls_by_version(dump_schema)
+        assert by_version[1] == [{ping: f"{ping}-v1" for ping in self.PING_TYPES}]
+        assert by_version[2] == [{"metrics": "metrics-v2"}]
 
     @patch("mozilla_schema_generator.__main__.dump_schema")
     def test_v2_allowlist_write_v1_only(
@@ -1314,7 +1416,7 @@ class TestGleanGeneration:
         glean_v2_allowlist,
         glean_v1_overwrite_allowlist,
     ):
-        """Should write only v1 with metrics blocklist when in v1_overwrite allowlist."""
+        """An app in neither allowlist should be generated as v1 only."""
         repo = {"app_id": "other-app"}
 
         msg_main.write_schema(
@@ -1332,6 +1434,10 @@ class TestGleanGeneration:
         mock_glean_ping.assert_any_call(
             repo, mps_branch="", version=1, use_metrics_blocklist=False
         )
+
+        by_version = self.dump_calls_by_version(dump_schema)
+        assert by_version[1] == [{ping: f"{ping}-v1" for ping in self.PING_TYPES}]
+        assert 2 not in by_version
 
     def test_check_blocked_distribution_metrics(self):
         """Should detect when distributions are blocked.


### PR DESCRIPTION
For https://mozilla-hub.atlassian.net/browse/DENG-8494

This will create v2 tables for fenix and desktop metrics.  Adding these tables before the rest because they are the ones that will benefit from this change, and keeping the number of tables low for this next phase will make it easier to validate.

Also makes changes to the v1 overwrite allowlist to be per ping instead of per app. Also also makes the unit tests actually test output.