### PR TITLE
[DENG-10517] Dedupe moved glean metrics

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -198,6 +198,25 @@ class GleanPing(GenericPing):
                 for name, defn in dependency_probes.items()
             ]
 
+        # A metric can be moved between an app and its dependencies or between
+        # dependencies while probe scraper keeps the history in each location, so
+        # both definitions are returned. Keep the one with the most recent
+        # `dates.last` to avoid non-deterministic selection
+        def _latest_history_date(defn):
+            return max(
+                datetime.fromisoformat(h["dates"]["last"])
+                for h in defn[GleanProbe.history_key]
+            )
+
+        deduped: Dict[str, Any] = {}
+        for name, defn in probes:
+            existing = deduped.get(name)
+            if existing is None or _latest_history_date(defn) > _latest_history_date(
+                existing
+            ):
+                deduped[name] = defn
+        probes = list(deduped.items())
+
         pings = self.get_pings()
 
         processed = []

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -198,15 +198,19 @@ class GleanPing(GenericPing):
                 for name, defn in dependency_probes.items()
             ]
 
-        # A metric can be moved between an app and its dependencies or between
-        # dependencies while probe scraper keeps the history in each location, so
-        # both definitions are returned. Keep the one with the most recent
-        # `dates.last` to avoid non-deterministic selection
+        # A metric can be moved between an app and its dependencies or between dependencies while
+        # probe scraper keeps the history in each location, so both definitions are returned
+        # Merge the history per probe to take the latest definition while still being able to
+        # find metric type changes below
         def _latest_history_date(defn):
             return max(
                 datetime.fromisoformat(h["dates"]["last"])
                 for h in defn[GleanProbe.history_key]
             )
+
+        merged_history: Dict[str, List[dict]] = defaultdict(list)
+        for name, defn in probes:
+            merged_history[name].extend(defn[GleanProbe.history_key])
 
         deduped: Dict[str, Any] = {}
         for name, defn in probes:
@@ -215,6 +219,13 @@ class GleanPing(GenericPing):
                 existing
             ):
                 deduped[name] = defn
+        for name in list(deduped):
+            defn = deduped[name].copy()
+            defn[GleanProbe.history_key] = sorted(
+                merged_history[name],
+                key=lambda h: datetime.fromisoformat(h["dates"]["first"]),
+            )
+            deduped[name] = defn
         probes = list(deduped.items())
 
         pings = self.get_pings()

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -202,31 +202,52 @@ class GleanPing(GenericPing):
         # probe scraper keeps the history in each location, so both definitions are returned
         # Merge the history per probe to take the latest definition while still being able to
         # find metric type changes below
+        # Metrics are not merged if they are not sent in the same pings as they are disjoint
+        def _pings_in_history(defn):
+            return {
+                p
+                for h in defn[GleanProbe.history_key]
+                for p in h.get("send_in_pings", ["metrics"])
+            }
+
         def _latest_history_date(defn):
             return max(
                 datetime.fromisoformat(h["dates"]["last"])
                 for h in defn[GleanProbe.history_key]
             )
 
-        merged_history: Dict[str, List[dict]] = defaultdict(list)
+        # Group same name probes whose pings intersect to combine moved metrics
+        grouped_by_name: Dict[str, List[List[dict]]] = defaultdict(list)
         for name, defn in probes:
-            merged_history[name].extend(defn[GleanProbe.history_key])
+            defn_pings = _pings_in_history(defn)
+            existing_groups = grouped_by_name[name]
+            matches = [
+                group
+                for group in existing_groups
+                if any(_pings_in_history(defn) & defn_pings for defn in group)
+            ]
+            if not matches:
+                existing_groups.append([defn])
+            else:
+                merged_group = [defn]
+                for g in matches:
+                    merged_group.extend(g)
+                    existing_groups.remove(g)
+                existing_groups.append(merged_group)
 
-        deduped: Dict[str, Any] = {}
-        for name, defn in probes:
-            existing = deduped.get(name)
-            if existing is None or _latest_history_date(defn) > _latest_history_date(
-                existing
-            ):
-                deduped[name] = defn
-        for name in list(deduped):
-            defn = deduped[name].copy()
-            defn[GleanProbe.history_key] = sorted(
-                merged_history[name],
-                key=lambda h: datetime.fromisoformat(h["dates"]["first"]),
-            )
-            deduped[name] = defn
-        probes = list(deduped.items())
+        # Take latest definition per group
+        deduped_probes: List[Any] = []
+        for name, groups in grouped_by_name.items():
+            for group in groups:
+                latest_defn = max(group, key=_latest_history_date)
+                if len(group) > 1:
+                    latest_defn = latest_defn.copy()
+                    latest_defn[GleanProbe.history_key] = sorted(
+                        (h for d in group for h in d[GleanProbe.history_key]),
+                        key=lambda h: datetime.fromisoformat(h["dates"]["first"]),
+                    )
+                deduped_probes.append((name, latest_defn))
+        probes = deduped_probes
 
         pings = self.get_pings()
 

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -1338,6 +1338,73 @@ class TestGleanPing(object):
         types = sorted(p.type for p in matches)
         assert types == ["labeled_counter", "quantity"]
 
+    @patch.object(glean_ping.GleanPing, "get_dependencies")
+    @patch.object(glean_ping.GleanPing, "get_app_name", return_value="firefox-ios")
+    @patch.object(glean_ping.GleanPing, "_get_json")
+    def test_same_name_different_pings_kept_separate(
+        self, mock_get_json, mock_app_name, mock_get_dependencies
+    ):
+        """Metrics sharing a name but sent in different pings should be kept as separate probes."""
+        mock_get_dependencies.return_value = ["sync"]
+
+        # App has a labeled_counter going to temp-history-sync only
+        app_defn = {
+            "history_sync.failure_reason": {
+                "history": [
+                    {
+                        "dates": {"first": "2025-01-01", "last": "2026-01-01"},
+                        "description": "ios",
+                        "type": "labeled_counter",
+                        "send_in_pings": ["temp-history-sync"],
+                    }
+                ],
+                "in-source": True,
+                "name": "history_sync.failure_reason",
+                "type": "labeled_counter",
+            }
+        }
+        # Dependency has a labeled_string going to history-sync only
+        dep_defn = {
+            "history_sync.failure_reason": {
+                "history": [
+                    {
+                        "dates": {"first": "2025-01-01", "last": "2026-01-01"},
+                        "description": "sync",
+                        "type": "labeled_string",
+                        "send_in_pings": ["history-sync"],
+                    }
+                ],
+                "in-source": True,
+                "name": "history_sync.failure_reason",
+                "type": "labeled_string",
+            }
+        }
+
+        def responses():
+            yield app_defn
+            yield dep_defn
+            while True:
+                yield {}
+
+        mock_get_json.side_effect = responses()
+
+        glean = glean_ping.GleanPing(
+            repo={
+                "name": "firefox-ios-release",
+                "app_id": "org-mozilla-ios-firefox",
+            },
+        )
+        probes = glean.get_probes()
+
+        matches = [p for p in probes if p.id == "history_sync.failure_reason"]
+
+        assert len(matches) == 2
+        types_to_pings = {p.type: p.definition.get("send_in_pings") for p in matches}
+        assert types_to_pings == {
+            "labeled_counter": {"temp-history-sync"},
+            "labeled_string": {"history-sync"},
+        }
+
 
 class TestGleanGeneration:
     @pytest.fixture

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -1216,12 +1216,58 @@ class TestGleanPing(object):
             probe.id for probe in probes if len(probe.definition["send_in_pings"]) > 0
         ]
 
-        assert len(active_probes) == 4
+        assert len(active_probes) == 3
         assert set(active_probes) == {
             "active",
             "expired_old",
             "expired_old_2",
         }
+
+    @patch.object(glean_ping.GleanPing, "get_dependencies")
+    @patch.object(glean_ping.GleanPing, "get_app_name", return_value="fenix")
+    @patch.object(glean_ping.GleanPing, "_get_json")
+    def test_duplicate_metric_keeps_most_recent_definition(
+        self, mock_get_json, mock_app_name, mock_get_dependencies
+    ):
+        """When the same metric exists in both the app and a dependency,
+        get_probes should keep only the definition with the most recent history."""
+        mock_get_dependencies.return_value = ["glean-core"]
+
+        # App has the stale copy (last update 2024-01-01); dependency has the
+        # active copy (last update 2026-05-01). The dependency definition should win.
+        app_defn = self.metric_def(
+            "media.audio.init_failure", "2023-01-01", "2024-01-01", True
+        )
+        dep_defn = self.metric_def(
+            "media.audio.init_failure", "2025-01-01", "2026-05-01", True
+        )
+        dep2_defn = self.metric_def(
+            "media.audio.init_failure", "2024-01-01", "2025-05-01", True
+        )
+        app_defn["media.audio.init_failure"]["history"][0]["description"] = "stale"
+        dep_defn["media.audio.init_failure"]["history"][0]["description"] = "active"
+        dep2_defn["media.audio.init_failure"]["history"][0]["description"] = "stale"
+
+        def responses():
+            yield dep_defn
+            yield app_defn
+            yield dep2_defn
+            while True:
+                yield {}
+
+        mock_get_json.side_effect = responses()
+
+        glean = glean_ping.GleanPing(
+            repo={
+                "name": "firefox-android-release",
+                "app_id": "org-mozilla-firefox",
+            },
+        )
+        probes = glean.get_probes()
+
+        matches = [p for p in probes if p.id == "media.audio.init_failure"]
+        assert len(matches) == 1
+        assert matches[0].definition["description"] == "active"
 
 
 class TestGleanGeneration:

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -1229,29 +1229,21 @@ class TestGleanPing(object):
     def test_duplicate_metric_keeps_most_recent_definition(
         self, mock_get_json, mock_app_name, mock_get_dependencies
     ):
-        """When the same metric exists in both the app and a dependency,
-        get_probes should keep only the definition with the most recent history."""
+        """The most recent definition should be used if there are duplicates found."""
         mock_get_dependencies.return_value = ["glean-core"]
 
-        # App has the stale copy (last update 2024-01-01); dependency has the
-        # active copy (last update 2026-05-01). The dependency definition should win.
         app_defn = self.metric_def(
-            "media.audio.init_failure", "2023-01-01", "2024-01-01", True
-        )
-        dep_defn = self.metric_def(
             "media.audio.init_failure", "2025-01-01", "2026-05-01", True
         )
-        dep2_defn = self.metric_def(
-            "media.audio.init_failure", "2024-01-01", "2025-05-01", True
+        dep_defn = self.metric_def(
+            "media.audio.init_failure", "2023-01-01", "2025-01-01", True
         )
-        app_defn["media.audio.init_failure"]["history"][0]["description"] = "stale"
-        dep_defn["media.audio.init_failure"]["history"][0]["description"] = "active"
-        dep2_defn["media.audio.init_failure"]["history"][0]["description"] = "stale"
+        app_defn["media.audio.init_failure"]["history"][0]["description"] = "active"
+        dep_defn["media.audio.init_failure"]["history"][0]["description"] = "stale"
 
         def responses():
-            yield dep_defn
             yield app_defn
-            yield dep2_defn
+            yield dep_defn
             while True:
                 yield {}
 
@@ -1268,6 +1260,83 @@ class TestGleanPing(object):
         matches = [p for p in probes if p.id == "media.audio.init_failure"]
         assert len(matches) == 1
         assert matches[0].definition["description"] == "active"
+
+    @patch.object(glean_ping.GleanPing, "get_dependencies")
+    @patch.object(glean_ping.GleanPing, "get_app_name", return_value="fenix")
+    @patch.object(glean_ping.GleanPing, "_get_json")
+    def test_duplicate_metric_preserves_history_across_sources(
+        self, mock_get_json, mock_app_name, mock_get_dependencies
+    ):
+        """Metric type changes should be preserved when a metric is moved."""
+        mock_get_dependencies.return_value = ["engine-gecko"]
+
+        # App is the current location with a labeled_counter type
+        app_defn = {
+            "avif.aom_decode_error": {
+                "history": [
+                    {
+                        "dates": {
+                            "first": "2024-02-19",
+                            "last": "2026-05-14",
+                        },
+                        "description": "current",
+                        "type": "labeled_counter",
+                        "send_in_pings": ["metrics"],
+                    }
+                ],
+                "in-source": True,
+                "name": "avif.aom_decode_error",
+                "type": "labeled_counter",
+            }
+        }
+        # Dependency is the prior location and the metric used to be a quantity there
+        dep_defn = {
+            "avif.aom_decode_error": {
+                "history": [
+                    {
+                        "dates": {
+                            "first": "2021-02-09",
+                            "last": "2024-02-12",
+                        },
+                        "description": "old",
+                        "type": "labeled_counter",
+                        "send_in_pings": ["metrics"],
+                    },
+                    {
+                        "dates": {
+                            "first": "2020-11-03",
+                            "last": "2021-01-18",
+                        },
+                        "description": "old",
+                        "type": "quantity",
+                        "send_in_pings": ["metrics"],
+                    },
+                ],
+                "in-source": True,
+                "name": "avif.aom_decode_error",
+                "type": "labeled_counter",
+            }
+        }
+
+        def responses():
+            yield app_defn
+            yield dep_defn
+            while True:
+                yield {}
+
+        mock_get_json.side_effect = responses()
+
+        glean = glean_ping.GleanPing(
+            repo={
+                "name": "firefox-android-release",
+                "app_id": "org-mozilla-firefox",
+            },
+        )
+        probes = glean.get_probes()
+
+        matches = [p for p in probes if p.id == "avif.aom_decode_error"]
+        types = sorted(p.type for p in matches)
+        assert types == ["labeled_counter", "quantity"]
 
 
 class TestGleanGeneration:


### PR DESCRIPTION
Fixes a bug where moved metrics are duplicated and the one that gets selected is non-deterministic, causing the description to constantly flip between the two, e.g. https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/5715eb284c90f3f7cf89fb9734edf34b8b635ac7

temporariliy rebased on https://github.com/mozilla/mozilla-schema-generator/tree/benwu/diff-changes to test the changes: https://github.com/mozilla/mozilla-schema-generator/commit/5e87a65bd146c9c05c6d1a00d44534f54121d31c