### PR TITLE
[DENG-10517] Dedupe same name metrics for real this time

### DIFF
--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -203,6 +203,14 @@ class GleanPing(GenericPing):
         # Merge the history per probe to take the latest definition while still being able to
         # find metric type changes below
         # Metrics are not merged if they are not sent in the same pings as they are disjoint
+
+        # Metrics are grouped by their normalized BigQuery column name (from jsonschema-transpiler)
+        # rather than their raw name. e.g. "media.audio.init_failure" and "media.audio_init_failure"
+        # normalize to "media_audio_init_failure". The transpiler picks one of the colliding
+        # descriptions non-deterministically.
+        def _normalize_name(name):
+            return name.replace(".", "_").replace("-", "_")
+
         def _pings_in_history(defn):
             return {
                 p
@@ -216,15 +224,26 @@ class GleanPing(GenericPing):
                 for h in defn[GleanProbe.history_key]
             )
 
-        # Group same name probes whose pings intersect to combine moved metrics
+        def _dedupe_sort_key(defn):
+            """Prefer the most recent definition, breaking ties by choosing the in-source metric."""
+            return (
+                _latest_history_date(defn),
+                defn.get(GleanProbe.in_source_key, False),
+                defn["name"],
+            )
+
+        # Group probes that share a normalized name and whose pings intersect to combine
+        # moved metrics and metrics that only differ by "." vs "_"
         grouped_by_name: Dict[str, List[List[dict]]] = defaultdict(list)
         for name, defn in probes:
             defn_pings = _pings_in_history(defn)
-            existing_groups = grouped_by_name[name]
+            existing_groups = grouped_by_name[_normalize_name(name)]
             matches = [
                 group
                 for group in existing_groups
-                if any(_pings_in_history(defn) & defn_pings for defn in group)
+                if any(
+                    _pings_in_history(other_defn) & defn_pings for other_defn in group
+                )
             ]
             if not matches:
                 existing_groups.append([defn])
@@ -237,16 +256,16 @@ class GleanPing(GenericPing):
 
         # Take latest definition per group
         deduped_probes: List[Any] = []
-        for name, groups in grouped_by_name.items():
+        for groups in grouped_by_name.values():
             for group in groups:
-                latest_defn = max(group, key=_latest_history_date)
+                latest_defn = max(group, key=_dedupe_sort_key)
                 if len(group) > 1:
                     latest_defn = latest_defn.copy()
                     latest_defn[GleanProbe.history_key] = sorted(
                         (h for d in group for h in d[GleanProbe.history_key]),
                         key=lambda h: datetime.fromisoformat(h["dates"]["first"]),
                     )
-                deduped_probes.append((name, latest_defn))
+                deduped_probes.append((latest_defn["name"], latest_defn))
         probes = deduped_probes
 
         pings = self.get_pings()

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -1405,6 +1405,73 @@ class TestGleanPing(object):
             "labeled_string": {"history-sync"},
         }
 
+    @patch.object(glean_ping.GleanPing, "get_dependencies")
+    @patch.object(glean_ping.GleanPing, "get_app_name", return_value="fenix")
+    @patch.object(glean_ping.GleanPing, "_get_json")
+    def test_duplicate_metric_differing_by_dot_or_underscore_deduped(
+        self, mock_get_json, mock_app_name, mock_get_dependencies
+    ):
+        """Metrics differing by "." and "_" that normalize to the same name should be deduped."""
+        mock_get_dependencies.return_value = ["engine-gecko"]
+
+        # Current metric, dotted name, most recent definition
+        app_defn = {
+            "media.audio.init_failure": {
+                "history": [
+                    {
+                        "dates": {"first": "2024-02-10", "last": "2026-06-15"},
+                        "description": "current",
+                        "type": "labeled_counter",
+                        "send_in_pings": ["metrics"],
+                    }
+                ],
+                "in-source": True,
+                "name": "media.audio.init_failure",
+                "type": "labeled_counter",
+            }
+        }
+        # Stale alias left in a dependency, underscore name, older and out of source
+        dep_defn = {
+            "media.audio_init_failure": {
+                "history": [
+                    {
+                        "dates": {"first": "2020-11-05", "last": "2020-11-05"},
+                        "description": "stale",
+                        "type": "labeled_counter",
+                        "send_in_pings": ["metrics"],
+                    }
+                ],
+                "in-source": False,
+                "name": "media.audio_init_failure",
+                "type": "labeled_counter",
+            }
+        }
+
+        def responses():
+            yield app_defn
+            yield dep_defn
+            while True:
+                yield {}
+
+        mock_get_json.side_effect = responses()
+
+        glean = glean_ping.GleanPing(
+            repo={
+                "name": "firefox-android-release",
+                "app_id": "org-mozilla-firefox",
+            },
+        )
+        probes = glean.get_probes()
+
+        matches = [
+            p
+            for p in probes
+            if p.id in ("media.audio.init_failure", "media.audio_init_failure")
+        ]
+        assert len(matches) == 1
+        assert matches[0].id == "media.audio.init_failure"
+        assert matches[0].definition["description"] == "current"
+
 
 class TestGleanGeneration:
     @pytest.fixture


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-10517

https://github.com/mozilla/mozilla-schema-generator/pull/318 didn't fully fix the issue because metrics can have different names but normalize to the same name for the bigquery column.  I think the non-deterministic slection happens in the jsonschema-transpiler around here
https://github.com/mozilla/jsonschema-transpiler/blob/7be6bea2d89fb4491b1a331a39a2d7a0c9010b2f/src/ast.rs#L393.

The fix here is to dedupe on the normalized name