### PR TITLE
Remove PR ref from first schema diff commit

### DIFF
--- a/.github/workflows/schema-diff.yml
+++ b/.github/workflows/schema-diff.yml
@@ -141,7 +141,7 @@ jobs:
           mkdir -p schema_out
           cp -r /tmp/main-schemas/. schema_out/
           git add schema_out
-          git commit --allow-empty -m "PR #${PR_NUMBER}: generated schemas from main (${MAIN_SHA:0:8})"
+          git commit --allow-empty -m "generated schemas from main (${MAIN_SHA:0:8})"
 
           # Commit 2: schemas generated from PR head
           rm -rf schema_out


### PR DESCRIPTION
Removes the PR number from the first diff commit that has the schemas from main so that only one `github-actions Bot added a commit that referenced this pull request` line shows up per commit to the branch, which will reduce the noise and keep only the one that's important