### PR TITLE
Fix incompatibility allowlist for v2 schemas

### DIFF
--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -123,19 +123,21 @@ telemetry.first-shutdown.4
 telemetry.saved-session.*
 telemetry.saved-session-use-counter.*
 
-# DENG-10876
+# DENG-10877
 org-mozilla-fenix-nightly.metrics.1
 org-mozilla-fenix-nightly.sync.1
-org-mozilla-fenix-nightly.first_session.1
-org-mozilla-fenix-nightly.adjust_attribution.1
+org-mozilla-fenix-nightly.first-session.1
+org-mozilla-fenix-nightly.adjust-attribution.1
 org-mozilla-fenix-nightly.health.1
-org-mozilla-fenix-nightly.captcha_detection.1
+org-mozilla-fenix-nightly.captcha-detection.1
+org-mozilla-fenix-nightly.play-store-attribution.1
 org-mozilla-fennec-aurora.metrics.1
 org-mozilla-fennec-aurora.sync.1
-org-mozilla-fennec-aurora.captcha_detection.1
-org-mozilla-fennec-aurora.first_session.1
+org-mozilla-fennec-aurora.captcha-detection.1
+org-mozilla-fennec-aurora.first-session.1
 org-mozilla-fennec-aurora.health.1
-org-mozilla-fennec-aurora.adjust_attribution.1
+org-mozilla-fennec-aurora.adjust-attribution.1
+org-mozilla-fennec-aurora.play-store-attribution.1
 
 # SVCSE-4447
 # Remove coverage pings


### PR DESCRIPTION
hyphens instead of underscores. Also I missed play-store-attribution for some reason