### PR TITLE
Remove test apps from v2 allowlist 

### DIFF
--- a/incompatibility-allowlist
+++ b/incompatibility-allowlist
@@ -124,20 +124,18 @@ telemetry.saved-session.*
 telemetry.saved-session-use-counter.*
 
 # DENG-10877
-org-mozilla-fenix-nightly.metrics.1
-org-mozilla-fenix-nightly.sync.1
-org-mozilla-fenix-nightly.first-session.1
-org-mozilla-fenix-nightly.adjust-attribution.1
-org-mozilla-fenix-nightly.health.1
-org-mozilla-fenix-nightly.captcha-detection.1
-org-mozilla-fenix-nightly.play-store-attribution.1
-org-mozilla-fennec-aurora.metrics.1
-org-mozilla-fennec-aurora.sync.1
-org-mozilla-fennec-aurora.captcha-detection.1
-org-mozilla-fennec-aurora.first-session.1
-org-mozilla-fennec-aurora.health.1
-org-mozilla-fennec-aurora.adjust-attribution.1
-org-mozilla-fennec-aurora.play-store-attribution.1
+org-mozilla-fenix-nightly.metrics.2
+org-mozilla-fenix-nightly.sync.2
+org-mozilla-fenix-nightly.first-session.2
+org-mozilla-fenix-nightly.adjust-attribution.2
+org-mozilla-fenix-nightly.health.2
+org-mozilla-fenix-nightly.captcha-detection.2
+org-mozilla-fennec-aurora.metrics.2
+org-mozilla-fennec-aurora.sync.2
+org-mozilla-fennec-aurora.captcha-detection.2
+org-mozilla-fennec-aurora.first-session.2
+org-mozilla-fennec-aurora.health.2
+org-mozilla-fennec-aurora.adjust-attribution.2
 
 # SVCSE-4447
 # Remove coverage pings

--- a/mozilla_schema_generator/__main__.py
+++ b/mozilla_schema_generator/__main__.py
@@ -185,7 +185,7 @@ def generate_glean_pings(config, out_dir, pretty, mps_branch, repo, generic_sche
     glean_config = Config("glean", config_data)
 
     with open(CONFIGS_DIR / "glean_v2_allowlist.yaml", "r") as f:
-        v2_allowlist = yaml.safe_load(f)
+        v2_allowlist = yaml.safe_load(f) or {}
 
     with open(CONFIGS_DIR / "glean_v1_overwrite_blocklist.yaml", "r") as f:
         v1_overwrite_blocklist = yaml.safe_load(f) or {}

--- a/mozilla_schema_generator/configs/glean_v2_allowlist.yaml
+++ b/mozilla_schema_generator/configs/glean_v2_allowlist.yaml
@@ -70,20 +70,6 @@
 # - first-session
 # - captcha-detection
 # - adjust-attribution
-org-mozilla-fenix-nightly:
-- metrics
-- sync
-- first-session
-- adjust-attribution
-- health
-- captcha-detection
-org-mozilla-fennec-aurora:
-- metrics
-- sync
-- captcha-detection
-- first-session
-- health
-- adjust-attribution
 # org-mozilla-firefox:
 # - metrics
 # - health


### PR DESCRIPTION
v2 tables got re-created after the swap because they weren't removed from the allowlist in the previous commit. Removing them here so they get removed by jenkins