### PR TITLE
[DENG-8494] Add desktop and fenix to v2 allowlist, update metrics blocklist

### DIFF
--- a/bin/generate_metric_blocklist.py
+++ b/bin/generate_metric_blocklist.py
@@ -47,7 +47,7 @@ while apps:
     for name, info in metrics.items():
         if (
             datetime.datetime.fromisoformat(info["history"][-1]["dates"]["last"])
-            < datetime.datetime(2025, 1, 1)
+            < datetime.datetime(2025, 8, 1)
             and info["in-source"] is False
             and info["type"] != "event"
         ):

--- a/mozilla_schema_generator/configs/glean_v2_allowlist.yaml
+++ b/mozilla_schema_generator/configs/glean_v2_allowlist.yaml
@@ -11,13 +11,15 @@
 # firefox-crashreporter:
 # - metrics
 # - health
-# firefox-desktop:
-# - metrics
-# - health
-# - sync
-# - captcha-detection
-# - new-metric-capture-emulation
-# - pseudo-main
+firefox-desktop:
+- metrics
+- health
+- sync
+- captcha-detection
+- new-metric-capture-emulation
+- pseudo-main
+- usage-reporting
+- newtab
 # firefox-desktop-background-defaultagent:
 # - metrics
 # - health
@@ -60,30 +62,33 @@
 # net-thunderbird-android-daily:
 # - metrics
 # - health
-#org-mozilla-connect-firefox:
-#- metrics
-#- health
-# org-mozilla-fenix:
-# - metrics
-# - sync
-# - health
-# - first-session
-# - captcha-detection
-# - adjust-attribution
-# org-mozilla-firefox:
+# org-mozilla-connect-firefox:
 # - metrics
 # - health
-# - sync
-# - first-session
-# - captcha-detection
-# - adjust-attribution
-# org-mozilla-firefox-beta:
-# - metrics
-# - health
-# - sync
-# - first-session
-# - captcha-detection
-# - adjust-attribution
+org-mozilla-fenix:
+- metrics
+- sync
+- health
+- first-session
+- captcha-detection
+- adjust-attribution
+- play-store-attribution
+org-mozilla-firefox:
+- metrics
+- health
+- sync
+- first-session
+- captcha-detection
+- adjust-attribution
+- play-store-attribution
+org-mozilla-firefox-beta:
+- metrics
+- health
+- sync
+- first-session
+- captcha-detection
+- adjust-attribution
+- play-store-attribution
 # org-mozilla-firefox-vpn:
 # - daemonsession
 # - vpnsession

--- a/mozilla_schema_generator/configs/metric_blocklist.yaml
+++ b/mozilla_schema_generator/configs/metric_blocklist.yaml
@@ -191,6 +191,7 @@ fenix:
   - engine_tab.kills
   - events.total_uri_count
   - experiments.metrics.active_experiment
+  - first_session.adjust_attribution_timespan
   - metrics.activity_state_provider_error
   - metrics.credit_cards_autofill_count
   - metrics.credit_cards_deleted_count
@@ -200,6 +201,7 @@ fenix:
   - metrics.syncing_items
   - metrics.toolbar_position
   - metrics.total_uri_count
+  - navigation_bar.os_navigation_uses_gestures
   - perf.startup.app_on_create_to_glean_init
   - perf.startup.app_on_create_to_megazord_init
   - perf.startup.app_on_create_to_setup_in_main
@@ -233,6 +235,11 @@ fenix:
   - recent_bookmarks.show_all_bookmarks
   - search.default_engine.submission_url
   - search_terms.group_size_distribution
+  - shopping.product_page_visits
+  - shopping.settings.component_opted_out
+  - shopping.settings.disabled_ads
+  - shopping.settings.nimbus_disabled_shopping
+  - shopping.settings.user_has_onboarded
   - wallpapers.discovered_wallpaper_feature
 firefox_desktop:
   metrics:
@@ -250,6 +257,11 @@ firefox_desktop:
   - extensions.startup_cache_load_time
   - gecko.build_id
   - gecko.version
+  - mozstorage.sqlitejsm_transaction_timeout
+  - networking.doh_heuristic_ever_tripped
+  - networking.doh_heuristics_attempts
+  - networking.doh_heuristics_pass_count
+  - networking.doh_heuristics_result
   - ping.centre.send_failures
   - ping.centre.send_failures_by_namespace
   - ping.centre.send_successes_by_namespace
@@ -257,10 +269,88 @@ firefox_desktop:
   - private_attribution.measure_conversion
   - private_attribution.save_impression
   - private_browsing.window_open_during_teardown
+  - region.fetch_result
+  - region.fetch_time
+  - search.engine.default.verified
+  - search.engine.private.verified
+  - shopping.product_page_visits
+  - shopping.settings.auto_close_user_disabled
+  - shopping.settings.auto_open_user_disabled
+  - shopping.settings.component_opted_out
+  - shopping.settings.disabled_ads
+  - shopping.settings.has_onboarded
+  - shopping.settings.nimbus_disabled_shopping
   - startup.is_restored_by_macos
   - startup.run_from_dmg_install_outcome
+  - telemetry.clamping_time_hgrams
+  - update.skip_startup_update_reason
+  - urlbar.abandonment_count
+  - urlbar.engagement_count
+  - urlbar.impression.autofill_about
+  - urlbar.impression.autofill_adaptive
+  - urlbar.impression.autofill_origin
+  - urlbar.impression.autofill_other
+  - urlbar.impression.autofill_url
+  - urlbar.picked.autofill_about
+  - urlbar.picked.autofill_adaptive
+  - urlbar.picked.autofill_origin
+  - urlbar.picked.autofill_other
+  - urlbar.picked.autofill_url
+  - urlbar.picked.bookmark
+  - urlbar.picked.bookmark_adaptive
+  - urlbar.picked.clipboard
+  - urlbar.picked.dynamic
+  - urlbar.picked.dynamic_wikipedia
+  - urlbar.picked.extension
+  - urlbar.picked.formhistory
+  - urlbar.picked.history
+  - urlbar.picked.history_adaptive
+  - urlbar.picked.keyword
+  - urlbar.picked.navigational
+  - urlbar.picked.quickaction
+  - urlbar.picked.quicksuggest
+  - urlbar.picked.recent_search
+  - urlbar.picked.remotetab
+  - urlbar.picked.restrict_keyword_actions
+  - urlbar.picked.restrict_keyword_bookmarks
+  - urlbar.picked.restrict_keyword_history
+  - urlbar.picked.restrict_keyword_tabs
+  - urlbar.picked.searchengine
+  - urlbar.picked.searchmode.bookmarkmenu
+  - urlbar.picked.searchmode.handoff
+  - urlbar.picked.searchmode.historymenu
+  - urlbar.picked.searchmode.keywordoffer
+  - urlbar.picked.searchmode.oneoff
+  - urlbar.picked.searchmode.other
+  - urlbar.picked.searchmode.searchbutton
+  - urlbar.picked.searchmode.shortcut
+  - urlbar.picked.searchmode.tabmenu
+  - urlbar.picked.searchmode.tabtosearch
+  - urlbar.picked.searchmode.tabtosearch_onboard
+  - urlbar.picked.searchmode.topsites_newtab
+  - urlbar.picked.searchmode.topsites_urlbar
+  - urlbar.picked.searchmode.touchbar
+  - urlbar.picked.searchmode.typed
+  - urlbar.picked.searchsuggestion
+  - urlbar.picked.searchsuggestion_rich
+  - urlbar.picked.switchtab
+  - urlbar.picked.tabtosearch
+  - urlbar.picked.tip
+  - urlbar.picked.topsite
+  - urlbar.picked.trending
+  - urlbar.picked.trending_rich
+  - urlbar.picked.unknown
+  - urlbar.picked.visiturl
+  - urlbar.picked.weather
+  - urlbar.quick_suggest_ingest_time
+  - urlbar.tabtosearch.impressions
+  - urlbar.tabtosearch.impressions_onboarding
+  - urlbar.tips
   - widget.dark_mode
   - widget.pointing_devices
+firefox_desktop_background_update:
+  metrics:
+  - update.skip_startup_update_reason
 firefox_ios:
   metrics:
   - app_menu.library
@@ -268,11 +358,16 @@ firefox_ios:
   - application_services.pocket_stories_visible
   - application_services.recent_highlights_visible
   - firefox_home_page.cycle_wallpaper_button
+  - firefox_home_page.history_highlights_show_all
   - firefox_home_page.history_highlights_view
   - firefox_home_page.jump_back_in_section_view
   - firefox_home_page.your_library
+  - history.group_list
+  - history.num_visits
   - inactive_tabs_tray.open_recently_closed_list
   - inactive_tabs_tray.open_recently_closed_tab
+  - library.panel_pressed
+  - migration.image_sd_cache_cleanup
   - onboarding.sync_screen
   - onboarding.sync_screen_browse
   - onboarding.sync_screen_sign_up
@@ -282,12 +377,38 @@ firefox_ios:
   - onboarding.welcome_screen_sign_in
   - onboarding.welcome_screen_sign_up
   - page_action_menu.add_to_reading_list
+  - places_history_migration.duration
+  - places_history_migration.migration_ended_rate
+  - places_history_migration.migration_error_rate
+  - places_history_migration.num_migrated
+  - places_history_migration.num_to_migrate
   - pocket.open_story
   - preferences.block_popups
+  - preferences.jump_back_in
   - preferences.mail_client
+  - preferences.new_tab_experience
+  - preferences.pocket
+  - preferences.recently_saved
+  - preferences.recently_visited
+  - preferences.show_clipboard_bar
   - reading_list.mark_read
   - reading_list.mark_unread
+  - shopping.product_page_visits
+  - shopping.settings.component_opted_out
+  - shopping.settings.disabled_ads
+  - shopping.settings.nimbus_disabled_shopping
+  - shopping.settings.user_has_onboarded
   - sync.open_sync_home_shortcut
+  - tabs.close
+  - tabs.close_all
+  - tabs.cumulative_count
+  - tabs.grouped_tab_closed
+  - tabs.grouped_tab_search
+  - tabs.inactive_tabs_count
+  - tabs.new_tab_pressed
+  - tabs.normal_tabs_quantity
+  - tabs.open
+  - tabs.private_tabs_quantity
   - theme.automatic_mode
   - theme.automatic_slider_value
   - theme.name
@@ -307,9 +428,67 @@ firefox_reality:
   - windows.duration
 focus_android:
   metrics:
+  - autocomplete.domain_added
+  - autocomplete.domain_removed
+  - autocomplete.list_order_changed
+  - browser.default_search_engine
+  - browser.install_source
+  - browser.locale_override
+  - browser.report_site_issue_counter
+  - browser.search.ad_clicks
+  - browser.search.in_content
+  - browser.search.search_count
+  - browser.search.with_ads
+  - browser.total_uri_count
+  - metrics.search_widget_installed
+  - metrics.start_reason_activity_error
+  - metrics.start_reason_process_error
+  - mozilla_products.has_fenix_installed
+  - mozilla_products.is_fenix_default_browser
   - nimbus_experiments.nimbus_initial_fetch
+  - notifications.permission_granted
+  - perf.startup.startup_type
+  - preferences.user_theme
   - settings_screen.autocomplete_domain_added
   - settings_screen.whats_new_tapped
+  - shortcuts.shortcut_added_counter
+  - shortcuts.shortcut_opened_counter
+  - shortcuts.shortcut_removed_counter
+  - shortcuts.shortcuts_on_home_number
+  - tab_count.app_backgrounded
+  - tracking_protection.has_advertising_blocked
+  - tracking_protection.has_analytics_blocked
+  - tracking_protection.has_content_blocked
+  - tracking_protection.has_ever_changed_etp
+  - tracking_protection.has_social_blocked
+  - tracking_protection.toolbar_shield_clicked
+focus_ios:
+  metrics:
+  - app.keyboard_type
+  - app.opened_as_default_browser
+  - browser.pdf_viewer_used
+  - browser.total_uri_count
+  - browser_search.ad_clicks
+  - browser_search.in_content
+  - browser_search.search_count
+  - browser_search.with_ads
+  - default_browser_onboarding.dismiss_pressed
+  - default_browser_onboarding.go_to_settings_pressed
+  - mozilla_products.has_firefox_installed
+  - preferences.user_theme
+  - search.default_engine
+  - settings_screen.autocomplete_domain_added
+  - settings_screen.set_as_default_browser_pressed
+  - shortcuts.shortcut_added_counter
+  - shortcuts.shortcut_opened_counter
+  - shortcuts.shortcut_removed_counter
+  - shortcuts.shortcuts_on_home_number
+  - tracking_protection.has_advertising_blocked
+  - tracking_protection.has_analytics_blocked
+  - tracking_protection.has_content_blocked
+  - tracking_protection.has_ever_changed_etp
+  - tracking_protection.has_social_blocked
+  - tracking_protection.toolbar_shield_clicked
 gecko:
   metrics:
   - apz.scrollwheel_overshoot
@@ -317,11 +496,14 @@ gecko:
   - bounce.tracking.protection.enabled_at_startup
   - bounce.tracking.protection.enabled_dry_run_mode_at_startup
   - browser.ui.proton_enabled
+  - cert.validation_success_by_ca
   - cert_compression.brotli_saved_bytes
   - cert_compression.used
   - cert_compression.zlib_saved_bytes
   - cert_compression.zstd_saved_bytes
+  - cert_pinning.failures_by_ca
   - cert_verifier.cert_trust_evaluation_time
+  - cert_verifier.trust_obj_count
   - cookie.banners.click.handle_duration
   - cookie.banners.click.query_selector_run_count_per_window_frame
   - cookie.banners.click.query_selector_run_count_per_window_top_level
@@ -354,14 +536,20 @@ gecko:
   - fog.validation.gvsv_primary_height
   - fog.validation.gvsv_primary_width
   - fog.validation.some_object
+  - fontlist.gdi_init_total
   - formautofill.addresses.detected_sections_count
   - formautofill.addresses.submitted_sections_count
   - formautofill.credit_cards.detected_sections_count
   - formautofill.credit_cards.submitted_sections_count
+  - geckoview.content_process_lifetime
+  - geckoview.startup_runtime
   - geckoview.validation.build_id
   - geckoview.validation.version
   - gfx.tmp_writable
   - gifft.validation.main_ping_assembling
+  - glam_experiment.async_sheet_load
+  - glam_experiment.time
+  - http.proxy_type
   - ipc.received_messages.content_background
   - ipc.received_messages.content_foreground
   - ipc.received_messages.gpu_process
@@ -372,6 +560,18 @@ gecko:
   - ipc.sent_messages.gpu_process
   - ipc.sent_messages.parent_active
   - ipc.sent_messages.parent_inactive
+  - javascript.pageload.baseline_compile_time
+  - javascript.pageload.delazification_time
+  - javascript.pageload.execution_time
+  - javascript.pageload.gc_time
+  - javascript.pageload.parse_time
+  - javascript.pageload.protect_time
+  - javascript.pageload.xdr_encode_time
+  - ls.preparedatastore.processing_time
+  - ls.preparelsdatabase.processing_time
+  - ls.request.recv_cancellation
+  - ls.request.send_cancellation
+  - mathml.doc_count
   - media.decode_error_per_mime_type
   - netwerk.early_hints
   - netwerk.eh_link_type
@@ -381,13 +581,19 @@ gecko:
   - netwerk.http3_ech_outcome_real
   - network.data_size_pb_per_type
   - network.data_size_per_type
+  - network.http3_avg_read_interval
   - network.open_to_transaction_pending
   - networking.http_3_ecn_ce_ect0_ratio
   - networking.http_content_html5parser_ondatafinished_to_onstop_delay_negative
   - networking.http_content_ondatafinished_to_onstop_delay_negative
   - networking.https_upgrade_with_https_rr
+  - networking.set_cookie_expired_without_server_time
   - networking.speculative_connection_outcome
   - oskeystore.self_test
+  - performance.clone.deserialize.items
+  - performance.clone.deserialize.size
+  - performance.clone.deserialize.time
+  - performance.pageload.async_sheet_load
   - performance.pageload.eh_fcp_preconnect
   - performance.pageload.eh_fcp_preconnect_preload_with_eh
   - performance.pageload.eh_fcp_preconnect_preload_without_eh
@@ -397,12 +603,19 @@ gecko:
   - performance.responsiveness.req_anim_frame_callback
   - pkcs11.built_in_roots_module
   - pkcs11.nss_cert_db
+  - privacy.sanitize.load_time
+  - process.lifetime
   - rtcrtpsender.setparameters.blame_length_changed
   - rtcrtpsender.setparameters.blame_no_getparameters
   - rtcrtpsender.setparameters.blame_no_transactionid
   - rtcrtpsender.setparameters.blame_stale_transactionid
   - rtcrtpsender.setparameters.warn_rid_changed
   - rtcrtpsender.setparameters.warn_stale_transactionid
+  - ssl.ct_policy_non_compliant_connections_by_ca
+  - timestamps.global_startup_timeline
+  - timestamps.startup_timeline
+  - translations.error_rate
+  - translations.requests_count
 glean-android:
   metrics:
   - glean.core.migration.successful
@@ -417,9 +630,67 @@ glean-core:
   - ping_reason
 klar_android:
   metrics:
+  - autocomplete.domain_added
+  - autocomplete.domain_removed
+  - autocomplete.list_order_changed
+  - browser.default_search_engine
+  - browser.install_source
+  - browser.locale_override
+  - browser.report_site_issue_counter
+  - browser.search.ad_clicks
+  - browser.search.in_content
+  - browser.search.search_count
+  - browser.search.with_ads
+  - browser.total_uri_count
+  - metrics.search_widget_installed
+  - metrics.start_reason_activity_error
+  - metrics.start_reason_process_error
+  - mozilla_products.has_fenix_installed
+  - mozilla_products.is_fenix_default_browser
   - nimbus_experiments.nimbus_initial_fetch
+  - notifications.permission_granted
+  - perf.startup.startup_type
+  - preferences.user_theme
   - settings_screen.autocomplete_domain_added
   - settings_screen.whats_new_tapped
+  - shortcuts.shortcut_added_counter
+  - shortcuts.shortcut_opened_counter
+  - shortcuts.shortcut_removed_counter
+  - shortcuts.shortcuts_on_home_number
+  - tab_count.app_backgrounded
+  - tracking_protection.has_advertising_blocked
+  - tracking_protection.has_analytics_blocked
+  - tracking_protection.has_content_blocked
+  - tracking_protection.has_ever_changed_etp
+  - tracking_protection.has_social_blocked
+  - tracking_protection.toolbar_shield_clicked
+klar_ios:
+  metrics:
+  - app.keyboard_type
+  - app.opened_as_default_browser
+  - browser.pdf_viewer_used
+  - browser.total_uri_count
+  - browser_search.ad_clicks
+  - browser_search.in_content
+  - browser_search.search_count
+  - browser_search.with_ads
+  - default_browser_onboarding.dismiss_pressed
+  - default_browser_onboarding.go_to_settings_pressed
+  - mozilla_products.has_firefox_installed
+  - preferences.user_theme
+  - search.default_engine
+  - settings_screen.autocomplete_domain_added
+  - settings_screen.set_as_default_browser_pressed
+  - shortcuts.shortcut_added_counter
+  - shortcuts.shortcut_opened_counter
+  - shortcuts.shortcut_removed_counter
+  - shortcuts.shortcuts_on_home_number
+  - tracking_protection.has_advertising_blocked
+  - tracking_protection.has_analytics_blocked
+  - tracking_protection.has_content_blocked
+  - tracking_protection.has_ever_changed_etp
+  - tracking_protection.has_social_blocked
+  - tracking_protection.toolbar_shield_clicked
 logins-store:
   metrics:
   - logins_store.migration_errors
@@ -446,13 +717,19 @@ pine:
   - extensions.startup_cache_load_time
   - gecko.build_id
   - gecko.version
+  - messaging_system.glean_ping_for_ping_failures
   - ping.centre.send_failures
   - ping.centre.send_failures_by_namespace
   - ping.centre.send_successes_by_namespace
+  - search.engine.default.verified
+  - search.engine.private.verified
   - startup.run_from_dmg_install_outcome
+  - telemetry.clamping_time_hgrams
 reference_browser:
   metrics:
   - experiments.metrics.active_experiment
 thunderbird_desktop:
   metrics:
   - calendar.google_token_type
+  - mail.compact_bytes_recovered
+  - mail.mbox_write_errors

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -38,6 +38,15 @@ DEFAULT_SCHEMA_URL = SCHEMA_URL_TEMPLATE + SCHEMA_VERSION_TEMPLATE.format(
     schema_type="glean", version=1
 )
 
+# App ids with v2 schemas already deployed. Applying the metric blocklist to these would drop
+# columns that already exist in their tables, which isn't allowed, so they keep every metric.
+METRIC_BLOCKLIST_EXEMPT_APP_IDS = frozenset(
+    {
+        "org-mozilla-fenix-nightly",
+        "org-mozilla-fennec-aurora",
+    }
+)
+
 
 class GleanPing(GenericPing):
     probes_url_template = GenericPing.probe_info_base_url + "/glean/{}/metrics"
@@ -63,7 +72,7 @@ class GleanPing(GenericPing):
         self.app_id = repo["app_id"]
         self.version = version
 
-        if use_metrics_blocklist:
+        if use_metrics_blocklist and self.app_id not in METRIC_BLOCKLIST_EXEMPT_APP_IDS:
             self.metric_blocklist = self.get_metric_blocklist()
         else:
             self.metric_blocklist = {}

--- a/mozilla_schema_generator/glean_ping.py
+++ b/mozilla_schema_generator/glean_ping.py
@@ -147,7 +147,7 @@ class GleanPing(GenericPing):
             metric["in-source"]
             or len(blocked_pings) == 0
             or datetime.fromisoformat(metric["history"][-1]["dates"]["last"])
-            >= datetime(year=2025, month=1, day=1)
+            >= datetime(year=2025, month=8, day=1)
         ):
             return metric
 

--- a/tests/test_glean.py
+++ b/tests/test_glean.py
@@ -1153,6 +1153,60 @@ class TestGleanPing(object):
         }
 
     @patch.object(glean_ping.GleanPing, "get_dependencies")
+    @patch.object(glean_ping.GleanPing, "get_metric_blocklist")
+    @patch.object(glean_ping.GleanPing, "get_app_name", return_value="fenix")
+    @patch.object(glean_ping.GleanPing, "_get_json")
+    def test_metric_blocklist_exempt_app_id(
+        self, mock_get_json, mock_app_name, mock_metric_blocklist, mock_get_dependencies
+    ):
+        """Apps with v2 schemas already deployed should keep blocklisted metrics.
+
+        The blocklist is keyed on app name, which every fenix channel shares, so an already
+        migrated channel would otherwise lose columns that exist in its tables.
+        """
+        mock_metric_blocklist.return_value = {
+            "fenix": {"metrics": ["expired_in_source_old"]},
+            "glean-core": {"metrics": ["expired_old_dependency"]},
+        }
+        glean = glean_ping.GleanPing(
+            repo={
+                "name": "fenix-nightly",
+                "app_id": "org-mozilla-fenix-nightly",
+            },
+            use_metrics_blocklist=True,
+        )
+        mock_get_dependencies.return_value = ["glean-core"]
+
+        def responses():
+            yield {
+                **self.metric_def("active", "2024-01-01", "2026-01-01", True),
+                **self.metric_def(
+                    "expired_in_source_old", "2024-01-01", "2024-01-01", False
+                ),
+            }
+            # metrics for dependency
+            yield {
+                **self.metric_def(
+                    "expired_old_dependency", "2024-01-01", "2024-01-01", False
+                ),
+            }
+            # /pings
+            while True:
+                yield {}
+
+        mock_get_json.side_effect = responses()
+
+        probes = glean.get_probes()
+
+        assert {
+            probe.id for probe in probes if len(probe.definition["send_in_pings"]) > 0
+        } == {
+            "active",
+            "expired_in_source_old",
+            "expired_old_dependency",
+        }
+
+    @patch.object(glean_ping.GleanPing, "get_dependencies")
     @patch.object(glean_ping.GleanPing, "get_app_name", return_value="fenix")
     @patch.object(glean_ping.GleanPing, "_get_json")
     def test_duplicate_metric_keeps_most_recent_definition(


### PR DESCRIPTION
Creating v2 tables for desktop and fenix. Not doing much yet, but I want to have the schemas to test https://mozilla-hub.atlassian.net/browse/DENG-11473 and redo performance test.

List of table is from 
```sql
WITH glean_ping_2_tables AS (
  SELECT 'firefox_desktop_stable' AS table_schema, table_name
  FROM `moz-fx-data-shared-prod.firefox_desktop_stable.INFORMATION_SCHEMA.TABLE_OPTIONS`
  WHERE option_name = 'labels' AND option_value LIKE '%STRUCT("schema_id", "glean_ping_2")%'
  UNION ALL
  SELECT 'org_mozilla_firefox_stable', table_name
  FROM `moz-fx-data-shared-prod.org_mozilla_firefox_stable.INFORMATION_SCHEMA.TABLE_OPTIONS`
  WHERE option_name = 'labels' AND option_value LIKE '%STRUCT("schema_id", "glean_ping_2")%'
  UNION ALL
  SELECT 'org_mozilla_fenix_stable', table_name
  FROM `moz-fx-data-shared-prod.org_mozilla_fenix_stable.INFORMATION_SCHEMA.TABLE_OPTIONS`
  WHERE option_name = 'labels' AND option_value LIKE '%STRUCT("schema_id", "glean_ping_2")%'
  UNION ALL
  SELECT 'org_mozilla_firefox_beta_stable', table_name
  FROM `moz-fx-data-shared-prod.org_mozilla_firefox_beta_stable.INFORMATION_SCHEMA.TABLE_OPTIONS`
  WHERE option_name = 'labels' AND option_value LIKE '%STRUCT("schema_id", "glean_ping_2")%'
),
distribution_tables AS (
  SELECT DISTINCT table_schema, table_name
  FROM `moz-fx-data-shared-prod.region-us.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS`
  WHERE table_schema IN ('firefox_desktop_stable', 'org_mozilla_firefox_stable', 'org_mozilla_fenix_stable', 'org_mozilla_firefox_beta_stable')
    AND field_path IN (
      'metrics.timing_distribution',
      'metrics.labeled_timing_distribution',
      'metrics.memory_distribution',
      'metrics.labeled_memory_distribution',
      'metrics.custom_distribution',
      'metrics.labeled_custom_distribution'
    )
)
SELECT
  d.table_schema || '.' || d.table_name AS table_name,
FROM distribution_tables d
LEFT JOIN glean_ping_2_tables g
  USING (table_schema, table_name)
WHERE g.table_name IS NULL
```

And metrics blocklist is updated to get everything that was removed >1 year ago as of 2026-08-01